### PR TITLE
Add Snapshotting support for event sourced aggregates

### DIFF
--- a/src/Broadway/EventSourcing/AggregateFactory/AggregateFactoryInterface.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/AggregateFactoryInterface.php
@@ -3,6 +3,7 @@
 namespace Broadway\EventSourcing\AggregateFactory;
 
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
 
 /**
  * Interface AggregateFactoryInterface
@@ -15,5 +16,5 @@ interface AggregateFactoryInterface
      *
      * @return \Broadway\EventSourcing\EventSourcedAggregateRoot
      */
-    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream);
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream, DomainMessage $snapshot);
 }

--- a/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
@@ -4,6 +4,7 @@ namespace Broadway\EventSourcing\AggregateFactory;
 
 use Assert\Assertion as Assert;
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
 
 /**
  * Creates aggregates by passing a DomainEventStream to the given public static method
@@ -25,7 +26,7 @@ class NamedConstructorAggregateFactory implements AggregateFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream, DomainMessage $snapshot = null)
     {
         Assert::true(method_exists($aggregateClass, $this->staticConstructorMethod));
 
@@ -34,7 +35,7 @@ class NamedConstructorAggregateFactory implements AggregateFactoryInterface
 
         Assert::isInstanceOf($aggregate, $aggregateClass);
 
-        $aggregate->initializeState($domainEventStream);
+        $aggregate->initializeState($domainEventStream, $snapshot);
 
         return $aggregate;
     }

--- a/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
@@ -3,6 +3,7 @@
 namespace Broadway\EventSourcing\AggregateFactory;
 
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
 
 /**
  * Creates aggregates by instantiating the aggregateClass and then
@@ -14,10 +15,10 @@ class PublicConstructorAggregateFactory implements AggregateFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream)
+    public function create($aggregateClass, DomainEventStreamInterface $domainEventStream, DomainMessage $snapshot = null)
     {
         $aggregate = new $aggregateClass();
-        $aggregate->initializeState($domainEventStream);
+        $aggregate->initializeState($domainEventStream, $snapshot);
 
         return $aggregate;
     }

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -62,8 +62,13 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
     /**
      * Initializes the aggregate using the given "history" of events.
      */
-    public function initializeState(DomainEventStreamInterface $stream)
+    public function initializeState(DomainEventStreamInterface $stream, DomainMessage $snapshot = null)
     {
+        if (null !== $snapshot) {
+            $this->playhead = $snapshot->getPlayhead();
+            $this->handleRecursively($snapshot->getPayload());
+        }
+
         foreach ($stream as $message) {
             $this->playhead++;
             $this->handleRecursively($message->getPayload());

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -27,6 +27,7 @@ use Broadway\Repository\RepositoryInterface;
 class EventSourcingRepository implements RepositoryInterface
 {
     private $eventStore;
+    private $snapshotStore;
     private $eventBus;
     private $aggregateClass;
     private $eventStreamDecorators = array();
@@ -44,11 +45,13 @@ class EventSourcingRepository implements RepositoryInterface
         EventBusInterface $eventBus,
         $aggregateClass,
         AggregateFactoryInterface $aggregateFactory,
-        array $eventStreamDecorators = array()
+        array $eventStreamDecorators = array(),
+        EventStoreInterface $snapshotStore = null
     ) {
         $this->assertExtendsEventSourcedAggregateRoot($aggregateClass);
 
         $this->eventStore            = $eventStore;
+        $this->snapshotStore         = $snapshotStore;
         $this->eventBus              = $eventBus;
         $this->aggregateClass        = $aggregateClass;
         $this->aggregateFactory      = $aggregateFactory;
@@ -60,10 +63,18 @@ class EventSourcingRepository implements RepositoryInterface
      */
     public function load($id)
     {
+        $playhead = 0;
+        $snapshot = null;
         try {
-            $domainEventStream = $this->eventStore->load($id);
+            if (null !== $this->snapshotStore) {
+                $snapshot = $this->snapshotStore->loadLast($id);
+                if (null !== $snapshot) {
+                    $playhead = $snapshot->getPlayhead();
+                }
+            }
+            $domainEventStream = $this->eventStore->load($id, $playhead);
 
-            return $this->aggregateFactory->create($this->aggregateClass, $domainEventStream);
+            return $this->aggregateFactory->create($this->aggregateClass, $domainEventStream, $snapshot);
         } catch (EventStreamNotFoundException $e) {
             throw AggregateNotFoundException::create($id, $e);
         }

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -63,7 +63,7 @@ class EventSourcingRepository implements RepositoryInterface
      */
     public function load($id)
     {
-        $playhead = 0;
+        $playhead = -1;
         $snapshot = null;
         try {
             if (null !== $this->snapshotStore) {
@@ -72,7 +72,7 @@ class EventSourcingRepository implements RepositoryInterface
                     $playhead = $snapshot->getPlayhead();
                 }
             }
-            $domainEventStream = $this->eventStore->load($id, $playhead);
+            $domainEventStream = $this->eventStore->load($id, $playhead + 1);
 
             return $this->aggregateFactory->create($this->aggregateClass, $domainEventStream, $snapshot);
         } catch (EventStreamNotFoundException $e) {

--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -69,10 +69,11 @@ class DBALEventStore implements EventStoreInterface
     /**
      * {@inheritDoc}
      */
-    public function load($id)
+    public function load($id, $playhead = 0)
     {
         $statement = $this->prepareLoadStatement();
         $statement->bindValue('uuid', $this->convertIdentifierToStorageValue($id));
+        $statement->bindValue('playhead', $playhead);
         $statement->execute();
 
         $events = array();
@@ -184,6 +185,7 @@ class DBALEventStore implements EventStoreInterface
             $query = 'SELECT uuid, playhead, metadata, payload, recorded_on
                 FROM ' . $this->tableName . '
                 WHERE uuid = :uuid
+                AND playhead >= :playhead
                 ORDER BY playhead ASC';
             $this->loadStatement = $this->connection->prepare($query);
         }

--- a/src/Broadway/EventStore/EventStoreInterface.php
+++ b/src/Broadway/EventStore/EventStoreInterface.php
@@ -20,10 +20,11 @@ interface EventStoreInterface
 {
     /**
      * @param mixed $id
+     * @param int $playhead
      *
      * @return DomainEventStreamInterface
      */
-    public function load($id);
+    public function load($id, $playhead);
 
     /**
      * @param mixed                      $id

--- a/src/Broadway/EventStore/EventStoreInterface.php
+++ b/src/Broadway/EventStore/EventStoreInterface.php
@@ -12,6 +12,7 @@
 namespace Broadway\EventStore;
 
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
 
 /**
  * Loads and stores events.
@@ -25,6 +26,13 @@ interface EventStoreInterface
      * @return DomainEventStreamInterface
      */
     public function load($id, $playhead);
+
+    /**
+     * @param mixed $id
+     *
+     * @return DomainMessage
+     */
+    public function loadLast($id);
 
     /**
      * @param mixed                      $id

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -49,6 +49,20 @@ class InMemoryEventStore implements EventStoreInterface
     /**
      * {@inheritDoc}
      */
+    public function loadLast($id)
+    {
+        $id = (string) $id;
+
+        if (isset($this->events[$id])) {
+            return end($this->events[$id]);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function append($id, DomainEventStreamInterface $eventStream)
     {
         $id = (string) $id;

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -26,12 +26,21 @@ class InMemoryEventStore implements EventStoreInterface
     /**
      * {@inheritDoc}
      */
-    public function load($id)
+    public function load($id, $playhead = 0)
     {
         $id = (string) $id;
 
         if (isset($this->events[$id])) {
-            return new DomainEventStream($this->events[$id]);
+            return new DomainEventStream(
+                array_values(
+                    array_filter(
+                        $this->events[$id],
+                        function ($event) use ($playhead) {
+                            return $playhead <= $event->getPlayhead();
+                        }
+                    )
+                )
+            );
         }
 
         throw new EventStreamNotFoundException(sprintf('EventStream not found for aggregate with id %s', $id));

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -65,6 +65,14 @@ class TraceableEventStore implements EventStoreInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function loadLast($id)
+    {
+        return $this->eventStore->loadLast($id);
+    }
+
+    /**
      * Start tracing.
      */
     public function trace()

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -59,9 +59,9 @@ class TraceableEventStore implements EventStoreInterface
     /**
      * {@inheritDoc}
      */
-    public function load($id)
+    public function load($id, $playhead = 0)
     {
-        return $this->eventStore->load($id);
+        return $this->eventStore->load($id, $playhead);
     }
 
     /**

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -116,6 +116,10 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
      */
     public function it_loads_an_aggregate_using_snapshots()
     {
+        $this->eventStore->append(42, new DomainEventStream(array(
+            DomainMessage::recordNow(42, 1, new Metadata(array()), new DidNumberEvent(1337))
+        )));
+
         $this->snapshotStore->append(42, new DomainEventStream(array(
             DomainMessage::recordNow(42, 1, new Metadata(array()), new TestEventSourcedAggregateSnapshot(array(1337, 1337)))
         )));

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -21,9 +21,9 @@ use Broadway\EventStore\TraceableEventStore;
 
 class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
 {
-    protected function createEventSourcingRepository(TraceableEventStore $eventStore, TraceableEventBus $eventBus, array $eventStreamDecorators)
+    protected function createEventSourcingRepository(TraceableEventStore $eventStore, TraceableEventBus $eventBus, array $eventStreamDecorators, TraceableEventStore $snapshotStore)
     {
-        return new EventSourcingRepository($eventStore, $eventBus, '\Broadway\EventSourcing\TestEventSourcedAggregate', new PublicConstructorAggregateFactory(), $eventStreamDecorators);
+        return new EventSourcingRepository($eventStore, $eventBus, '\Broadway\EventSourcing\TestEventSourcedAggregate', new PublicConstructorAggregateFactory(), $eventStreamDecorators, $snapshotStore);
     }
 
     protected function createAggregate()
@@ -108,6 +108,11 @@ class TestEventSourcedAggregate extends EventSourcedAggregateRoot
     protected function applyDidNumberEvent($event)
     {
         $this->numbers[] = $event->number;
+    }
+
+    protected function applyTestEventSourcedAggregateSnapshot($snapshot)
+    {
+        $this->numbers = $snapshot->numbers;
     }
 }
 

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -77,6 +77,30 @@ abstract class EventStoreTest extends TestCase
     /**
      * @test
      * @dataProvider idDataProvider
+     */
+    public function it_loads_events_starting_from_a_given_playhead($id)
+    {
+        $dateTime          = DateTime::fromString('2014-03-12T14:17:19.176169+00:00');
+        $domainEventStream = new DomainEventStream(array(
+            $this->createDomainMessage($id, 0, $dateTime),
+            $this->createDomainMessage($id, 1, $dateTime),
+            $this->createDomainMessage($id, 2, $dateTime),
+            $this->createDomainMessage($id, 3, $dateTime),
+        ));
+
+        $this->eventStore->append($id, $domainEventStream);
+
+        $expected = new DomainEventStream(array(
+            $this->createDomainMessage($id, 2, $dateTime),
+            $this->createDomainMessage($id, 3, $dateTime),
+        ));
+
+        $this->assertEquals($expected, $this->eventStore->load($id, 2));
+    }
+
+    /**
+     * @test
+     * @dataProvider idDataProvider
      * @expectedException Broadway\EventStore\EventStreamNotFoundException
      */
     public function it_throws_an_exception_when_requesting_the_stream_of_a_non_existing_aggregate($id)

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -101,6 +101,27 @@ abstract class EventStoreTest extends TestCase
     /**
      * @test
      * @dataProvider idDataProvider
+     */
+    public function it_loads_the_last_event_of_a_given_stream($id)
+    {
+        $dateTime          = DateTime::fromString('2014-03-12T14:17:19.176169+00:00');
+        $domainEventStream = new DomainEventStream(array(
+            $this->createDomainMessage($id, 0, $dateTime),
+            $this->createDomainMessage($id, 1, $dateTime),
+            $this->createDomainMessage($id, 2, $dateTime),
+            $this->createDomainMessage($id, 3, $dateTime),
+        ));
+
+        $this->eventStore->append($id, $domainEventStream);
+
+        $expected = $this->createDomainMessage($id, 3, $dateTime);
+
+        $this->assertEquals($expected, $this->eventStore->loadLast($id));
+    }
+
+    /**
+     * @test
+     * @dataProvider idDataProvider
      * @expectedException Broadway\EventStore\EventStreamNotFoundException
      */
     public function it_throws_an_exception_when_requesting_the_stream_of_a_non_existing_aggregate($id)


### PR DESCRIPTION
This Pull Request tries to address https://github.com/qandidate-labs/broadway/issues/111.

Snapshots are regular Domain Messages, but they are stored in a separate store, for the reasons described [here](https://groups.google.com/forum/#!msg/event-store/W4PnHcVFhDM/NCzjQkeJZXAJ).

The aggregate is responsible for generating snapshots on demand, and reconstitutig itself from a snapshot (ie implementing a `apply[MySnapshotClass]` method).
When a repository retrieves an agrgegate, it will first try to load the latest snapshot, then the events that were recorded after the snapshot was taken and pass those to the aggregate factory.

I've kept backward compatibilty.
