### PR TITLE
[WIP] Clear queue and pass incomplete command stack within SimpleCommandBus

### DIFF
--- a/src/Broadway/CommandHandling/Exception/CommandHandlingException.php
+++ b/src/Broadway/CommandHandling/Exception/CommandHandlingException.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling\Exception;
+
+use RuntimeException;
+
+/**
+ * Class CommandHandlingException
+ */
+class CommandHandlingException extends RuntimeException
+{
+    /**
+     * @var \Exception
+     */
+    private $originalException;
+
+    /**
+     * @var array
+     */
+    private $incompleteCommandStack;
+
+    /**
+     * @param \Exception $originalException
+     * @param array      $incompleteCommands
+     */
+    public function __construct(\Exception $originalException, array $incompleteCommands)
+    {
+        $this->originalException = $originalException;
+        $this->incompleteCommandStack = $incompleteCommands;
+
+        parent::__construct($originalException->getMessage(), $originalException->getCode(), $originalException);
+    }
+
+    /**
+     * @return \Exception
+     */
+    public function getOriginalException()
+    {
+        return $this->originalException;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIncompleteCommandStack()
+    {
+        return $this->incompleteCommandStack;
+    }
+}

--- a/src/Broadway/CommandHandling/HandlingExceptionAwareCommandBus.php
+++ b/src/Broadway/CommandHandling/HandlingExceptionAwareCommandBus.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Thomas Ploch <thomas.ploch@meinfernbus.de>
+ */
+
+namespace Broadway\CommandHandling;
+
+use Broadway\CommandHandling\Exception\CommandHandlingException;
+
+/**
+ * Class HandlingExceptionAwareCommandBus
+ */
+class HandlingExceptionAwareCommandBus implements CommandBusInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @param CommandBusInterface $commandBus
+     */
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dispatch($command)
+    {
+        try {
+            $this->commandBus->dispatch($command);
+        } catch (CommandHandlingException $handlingException) {
+            throw $handlingException->getOriginalException();
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function subscribe(CommandHandlerInterface $handler)
+    {
+        $this->commandBus->subscribe($handler);
+    }
+}

--- a/src/Broadway/CommandHandling/SimpleCommandBus.php
+++ b/src/Broadway/CommandHandling/SimpleCommandBus.php
@@ -11,6 +11,8 @@
 
 namespace Broadway\CommandHandling;
 
+use Broadway\CommandHandling\Exception\CommandHandlingException;
+
 /**
  * Simple synchronous dispatching of commands.
  */
@@ -47,8 +49,11 @@ class SimpleCommandBus implements CommandBusInterface
 
                 $this->isDispatching = false;
             } catch (\Exception $e) {
+                $incompleteCommands = $this->queue;
+                $this->queue = array();
                 $this->isDispatching = false;
-                throw $e;
+
+                throw new CommandHandlingException($e, $incompleteCommands);
             }
         }
     }

--- a/test/Broadway/CommandHandling/HandlingExceptionAwareCommandBusTest.php
+++ b/test/Broadway/CommandHandling/HandlingExceptionAwareCommandBusTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+use Broadway\CommandHandling\Exception\CommandHandlingException;
+use Broadway\TestCase;
+
+/**
+ * Class HandlingExceptionAwareCommandBusTest
+ */
+class HandlingExceptionAwareCommandBusTest extends TestCase
+{
+    /** @var  \PHPUnit_Framework_MockObject_MockObject|CommandBusInterface */
+    private $commandBusMock;
+
+    /**
+     * @var HandlingExceptionAwareCommandBus
+     */
+    private $handlingCommandBus;
+
+    protected function setUp()
+    {
+        $this->commandBusMock = $this
+            ->getMockBuilder(CommandBusInterface::class)
+            ->setMethods(['dispatch'])
+            ->getMockForAbstractClass();
+
+        $this->handlingCommandBus = new HandlingExceptionAwareCommandBus(
+            $this->commandBusMock
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_forwards_correct_exception_when_using_handling_exception()
+    {
+        $command = array('foo' => 'bar');
+        $originalException = new MyException();
+        $exception = new CommandHandlingException($originalException, []);
+
+        $this->commandBusMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->will($this->throwException($exception));
+
+        $this->setExpectedException(MyException::class);
+        $this->handlingCommandBus->dispatch($command);
+    }
+
+    /**
+     * @test
+     */
+    public function it_forwards_correct_exception()
+    {
+        $command = array('foo' => 'bar');
+        $exception = new MyException();
+
+        $this->commandBusMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($command)
+            ->will($this->throwException($exception));
+
+        $this->setExpectedException(MyException::class);
+        $this->handlingCommandBus->dispatch($command);
+    }
+}


### PR DESCRIPTION
After discussion with @wjzijderveld and @asm89 we discussed a solution that would make it possible to:

1.) Clear the queue within the SimpleCommandBus since we cannot give any guarantee that the remaining commands on the stack do not depend on the current failed one.

2.) Pass the incomplete command stack within the `EventDispatchingCommandBus` to enable further processing (retry strategy, logging, etc.)

This is a POC.

TODO:
- [x] Add test cases
- [x] Modify bundle service configurations
