### PR TITLE
IlluminateEventStore

### DIFF
--- a/src/Broadway/EventStore/IlluminateEventStore.php
+++ b/src/Broadway/EventStore/IlluminateEventStore.php
@@ -6,9 +6,9 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\DateTime;
 use Broadway\EventStore\EventStoreInterface;
 use Broadway\EventStore\EventStreamNotFoundException;
-use Broadway\EventStore\IlluminateEventStoreException;
 use Broadway\Serializer\SerializerInterface;
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Config\Repository;
+use Illuminate\Database\DatabaseManager;
 
 /**
  * Class IlluminateEventStore
@@ -21,7 +21,7 @@ use Illuminate\Contracts\Container\Container;
 class IlluminateEventStore implements EventStoreInterface {
 
     /**
-     * @var \Illuminate\Database\DatabaseManager
+     * @var DatabaseManager
      */
     protected $databaseManager;
 
@@ -38,15 +38,17 @@ class IlluminateEventStore implements EventStoreInterface {
     /**
      * Construct the dependancies
      *
-     * @param \Illuminate\Contracts\Container\Container $container
+     * @param \Illuminate\Database\DatabaseManager $databaseManager
+     * @param \Illuminate\Config\Repository $configRepository
      * @param SerializerInterface $serializer
      */
     public function __construct(
-        Container $container,
+        DatabaseManager $databaseManager,
+        Repository $configRepository,
         SerializerInterface $serializer
     ) {
-        $this->databaseManager = $container->make('db');
-        $this->config = $container->make('config');
+        $this->databaseManager = $databaseManager;
+        $this->config = $configRepository;
         $this->table = $this->config->get('broadway.table','event');
         $this->serializer = $serializer;
     }

--- a/src/Broadway/EventStore/IlluminateEventStore.php
+++ b/src/Broadway/EventStore/IlluminateEventStore.php
@@ -1,0 +1,117 @@
+<?php namespace App\Broadway\EventStore;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\DateTime;
+use Broadway\EventStore\EventStoreInterface;
+use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\EventStore\IlluminateEventStoreException;
+use Broadway\Serializer\SerializerInterface;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Class IlluminateEventStore
+ *
+ * Create a broadway.php config file in your config directory to change the table name
+ *
+ * @author  Dennis Schepers
+ * @package App\Broadway\EventStore
+ */
+class IlluminateEventStore implements EventStoreInterface {
+
+    /**
+     * @var \Illuminate\Database\DatabaseManager
+     */
+    protected $databaseManager;
+
+    /**
+     * @var \Broadway\Serializer\SerializerInterface
+     */
+    protected $serializer;
+
+    /**
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    protected $config;
+
+    /**
+     * Construct the dependancies
+     *
+     * @param \Illuminate\Contracts\Container\Container $container
+     * @param SerializerInterface $serializer
+     */
+    public function __construct(
+        Container $container,
+        SerializerInterface $serializer
+    ) {
+        $this->databaseManager = $container->make('db');
+        $this->config = $container->make('config');
+        $this->table = $this->config->get('broadway.table','event');
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($id)
+    {
+        $results = $this->databaseManager->connection()->table($this->table)->where('uuid', $id)->get();
+
+        if(!$results) {
+            throw new EventStreamNotFoundException(sprintf('EventStream not found for aggregate with id %s', $id));
+        }
+        $events = [];
+        foreach ($results as $row) {
+            $events[] = $this->deserializeEvent($row);
+        }
+        return new DomainEventStream($events);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function append($id, DomainEventStreamInterface $eventStream)
+    {
+        $connection = $this->databaseManager->connection();
+
+        try {
+            $connection->beginTransaction();
+            foreach ($eventStream as $domainMessage) {
+                /* @var $domainMessage DomainMessage */
+                $connection->table($this->table)->insertGetId([
+                        'uuid'        => (string) $domainMessage->getId(),
+                        'playhead'    => $domainMessage->getPlayhead(),
+                        'metadata'    => json_encode($this->serializer->serialize($domainMessage->getMetadata())),
+                        'payload'     => json_encode($this->serializer->serialize($domainMessage->getPayload())),
+                        'recorded_on' => $domainMessage->getRecordedOn()->toString(),
+                        'type'        => $domainMessage->getType(),
+                    ]);
+            }
+            $connection->commit();
+        } catch (\Exception $e) {
+            $connection->rollBack();
+            throw new IlluminateEventStoreException($e->getMessage(), $e->getCode(), $e->getPrevious());
+        }
+    }
+
+    /**
+     * Deserialize a result row to a DomainMessage
+     *
+     * @author Dennis Schepers
+     *
+     * @param $row
+     *
+     * @return \Broadway\Domain\DomainMessage
+     */
+    protected function deserializeEvent($row)
+    {
+        return new DomainMessage(
+            $row->uuid,
+            $row->playhead,
+            $this->serializer->deserialize(json_decode($row->metadata, true)),
+            $this->serializer->deserialize(json_decode($row->payload, true)),
+            DateTime::fromString($row->recorded_on)
+        );
+    }
+}

--- a/src/Broadway/EventStore/IlluminateEventStoreException.php
+++ b/src/Broadway/EventStore/IlluminateEventStoreException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Broadway\EventStore;
+
+/**
+ * Class IlluminateEventStoreException
+ *
+ * @author  Dennis Schepers
+ * @package Broadway\EventStore
+ */
+class IlluminateEventStoreException extends EventStoreException
+{
+}


### PR DESCRIPTION
IlluminateEventStore for use with Laravel and Lumen Frameworks.

This uses Illuminates query builder instead of Eloquent, since Eloquent would require the models, and Lumen's default configuration does not have Eloquent enabled.
