### PR TITLE
Make Saga's use DomainMessage instead of just the event/payload

### DIFF
--- a/src/Broadway/Saga/Metadata/Metadata.php
+++ b/src/Broadway/Saga/Metadata/Metadata.php
@@ -11,6 +11,7 @@
 
 namespace Broadway\Saga\Metadata;
 
+use Broadway\Domain\DomainMessage;
 use Broadway\Saga\MetadataInterface;
 use RuntimeException;
 
@@ -29,8 +30,9 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritDoc}
      */
-    public function handles($event)
+    public function handles(DomainMessage $domainMessage)
     {
+        $event = $domainMessage->getPayload();
         $eventName = $this->getClassName($event);
 
         return isset($this->criteria[$eventName]);
@@ -39,8 +41,9 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritDoc}
      */
-    public function criteria($event)
+    public function criteria(DomainMessage $domainMessage)
     {
+        $event = $domainMessage->getPayload();
         $eventName = $this->getClassName($event);
 
         if (! isset($this->criteria[$eventName])) {

--- a/src/Broadway/Saga/Metadata/Metadata.php
+++ b/src/Broadway/Saga/Metadata/Metadata.php
@@ -50,7 +50,7 @@ class Metadata implements MetadataInterface
             throw new RuntimeException(sprintf("No criteria for event '%s'.", $eventName));
         }
 
-        return $this->criteria[$eventName]($event);
+        return $this->criteria[$eventName]($event, $domainMessage);
     }
 
     private function getClassName($event)

--- a/src/Broadway/Saga/MetadataInterface.php
+++ b/src/Broadway/Saga/MetadataInterface.php
@@ -11,19 +11,22 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
 use Broadway\Saga\State\Criteria;
 
 interface MetadataInterface
 {
     /**
-     * @param mixed $event
+     * @param DomainMessage $domainMessage
      *
-     * @return boolean True, if the saga can handle the event
+     * @return bool True, if the saga can handle the event
      */
-    public function handles($event);
+    public function handles(DomainMessage $domainMessage);
 
     /**
+     * @param DomainMessage $domainMessage
+     *
      * @return Criteria Criteria for the given event
      */
-    public function criteria($event);
+    public function criteria(DomainMessage $domainMessage);
 }

--- a/src/Broadway/Saga/MultipleSagaManager.php
+++ b/src/Broadway/Saga/MultipleSagaManager.php
@@ -23,7 +23,9 @@ use Broadway\Saga\State\StateManager;
 class MultipleSagaManager implements SagaManagerInterface
 {
     private $repository;
+    private $sagas;
     private $stateManager;
+    private $metadataFactory;
     private $eventDispatcher;
 
     public function __construct(

--- a/src/Broadway/Saga/Saga.php
+++ b/src/Broadway/Saga/Saga.php
@@ -11,13 +11,17 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
+
 abstract class Saga implements SagaInterface
 {
     /**
      * {@inheritDoc}
      */
-    public function handle($event, State $state)
+    public function handle(DomainMessage $domainMessage, State $state)
     {
+        $event = $domainMessage->getPayload();
+
         $method = $this->getHandleMethod($event);
 
         if (! method_exists($this, $method)) {

--- a/src/Broadway/Saga/Saga.php
+++ b/src/Broadway/Saga/Saga.php
@@ -34,7 +34,7 @@ abstract class Saga implements SagaInterface
             );
         }
 
-        return $this->$method($event, $state);
+        return $this->$method($event, $state, $domainMessage);
     }
 
     private function getHandleMethod($event)

--- a/src/Broadway/Saga/SagaInterface.php
+++ b/src/Broadway/Saga/SagaInterface.php
@@ -11,12 +11,15 @@
 
 namespace Broadway\Saga;
 
+use Broadway\Domain\DomainMessage;
+
 interface SagaInterface
 {
     /**
-     * @param mixed $event
+     * @param DomainMessage $domainMessage
+     * @param State $state
      *
      * @return State
      */
-    public function handle($event, State $state);
+    public function handle(DomainMessage $domainMessage, State $state);
 }

--- a/test/Broadway/Saga/Metadata/MetadataTest.php
+++ b/test/Broadway/Saga/Metadata/MetadataTest.php
@@ -17,6 +17,9 @@ use Broadway\TestCase;
 
 class StaticallyConfiguredSagaMetadataTest extends TestCase
 {
+    /**
+     * @var Metadata
+     */
     private $metadata;
 
     public function setUp()
@@ -66,7 +69,7 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
 
     /**
      * @test
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function it_throws_an_exception_if_there_is_no_criteria_for_a_given_event()
     {

--- a/test/Broadway/Saga/Metadata/MetadataTest.php
+++ b/test/Broadway/Saga/Metadata/MetadataTest.php
@@ -11,6 +11,8 @@
 
 namespace Broadway\Saga\Metadata;
 
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata as DomainMetadata;
 use Broadway\TestCase;
 
 class StaticallyConfiguredSagaMetadataTest extends TestCase
@@ -31,7 +33,8 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent1();
 
-        $this->assertTrue($this->metadata->handles($event));
+        $domainMessage = $this->createDomainMessageForEvent($event);
+        $this->assertTrue($this->metadata->handles($domainMessage));
     }
 
     /**
@@ -41,7 +44,8 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent2();
 
-        $this->assertFalse($this->metadata->handles($event));
+        $domainMessage = $this->createDomainMessageForEvent($event);
+        $this->assertFalse($this->metadata->handles($domainMessage));
     }
 
     /**
@@ -51,7 +55,8 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent1();
 
-        $this->assertEquals('criteria', $this->metadata->criteria($event));
+        $domainMessage = $this->createDomainMessageForEvent($event);
+        $this->assertEquals('criteria', $this->metadata->criteria($domainMessage));
     }
 
     /**
@@ -62,7 +67,13 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     {
         $event = new StaticallyConfiguredSagaMetadataTestSagaTestEvent2();
 
-        $this->metadata->criteria($event);
+        $domainMessage = $this->createDomainMessageForEvent($event);
+        $this->metadata->criteria($domainMessage);
+    }
+
+    private function createDomainMessageForEvent($event)
+    {
+        return DomainMessage::recordNow(1, 0, new DomainMetadata(array()), $event);
     }
 }
 

--- a/test/Broadway/Saga/Metadata/MetadataTest.php
+++ b/test/Broadway/Saga/Metadata/MetadataTest.php
@@ -22,7 +22,12 @@ class StaticallyConfiguredSagaMetadataTest extends TestCase
     public function setUp()
     {
         $this->metadata = new Metadata(array(
-            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function () { return 'criteria'; },
+            'StaticallyConfiguredSagaMetadataTestSagaTestEvent1' => function ($event, $domainMessage) {
+                self::assertNotNull($event);
+                self::assertInstanceOf('Broadway\Domain\DomainMessage', $domainMessage);
+
+                return 'criteria';
+            },
         ));
     }
 

--- a/test/Broadway/Saga/MultipleSagaManagerTest.php
+++ b/test/Broadway/Saga/MultipleSagaManagerTest.php
@@ -26,11 +26,29 @@ use Broadway\UuidGenerator\Rfc4122\Version4Generator;
 
 class MultipleSagaManagerTest extends TestCase
 {
+    /**
+     * @var SagaManagerInterface
+     */
     private $manager;
+    /**
+     * @var TraceableSagaStateRepository
+     */
     private $repository;
+    /**
+     * @var array
+     */
     private $sagas;
+    /**
+     * @var StateManager
+     */
     private $stateManager;
+    /**
+     * @var StaticallyConfiguredSagaMetadataFactory
+     */
     private $metadataFactory;
+    /**
+     * @var TraceableEventDispatcher
+     */
     private $eventDispatcher;
 
     public function setUp()

--- a/test/Broadway/Saga/MultipleSagaManagerTest.php
+++ b/test/Broadway/Saga/MultipleSagaManagerTest.php
@@ -254,10 +254,11 @@ class MultipleSagaManagerTest extends TestCase
 class SagaManagerTestSaga implements StaticallyConfiguredSagaInterface
 {
     public $isCalled = false;
-    public function handle($event, State $state = null)
+    public function handle(DomainMessage $domainMessage, State $state = null)
     {
         $this->isCalled = true;
 
+        $event = $domainMessage->getPayload();
         if ($event instanceof TestEvent1) {
             $state->set('event', 'testevent1');
         } elseif ($event instanceof TestEvent2) {

--- a/test/Broadway/Saga/SagaMetadataEnricherTest.php
+++ b/test/Broadway/Saga/SagaMetadataEnricherTest.php
@@ -16,13 +16,24 @@ use Broadway\TestCase;
 
 class SagaMetadataEnricherTest extends TestCase
 {
+    /**
+     * @var SagaMetadataEnricher
+     */
     private $sagaMetadataEnricher;
+    /**
+     * @var Metadata
+     */
     private $metadata;
+    /**
+     * @var array
+     */
+    private $sagaData;
 
     public function setUp()
     {
         $this->sagaMetadataEnricher = new SagaMetadataEnricher();
         $this->metadata             = new Metadata(array('yolo' => 'tralelo'));
+        $this->sagaData             = array();
     }
 
     /**

--- a/test/Broadway/Saga/State/AbstractRepositoryTest.php
+++ b/test/Broadway/Saga/State/AbstractRepositoryTest.php
@@ -16,6 +16,9 @@ use Broadway\TestCase;
 
 abstract class AbstractRepositoryTest extends TestCase
 {
+    /**
+     * @var RepositoryInterface
+     */
     protected $repository;
 
     public function setUp()
@@ -98,7 +101,7 @@ abstract class AbstractRepositoryTest extends TestCase
 
     /**
      * @test
-     * @expectedException Broadway\Saga\State\RepositoryException
+     * @expectedException \Broadway\Saga\State\RepositoryException
      * @expectedExceptionMessage Multiple saga state instances found.
      */
     public function it_throws_an_exception_if_multiple_matching_elements_are_found()

--- a/test/Broadway/Saga/State/MongoDBRepositoryTest.php
+++ b/test/Broadway/Saga/State/MongoDBRepositoryTest.php
@@ -21,6 +21,9 @@ use Doctrine\MongoDB\Connection;
 class MongoDBRepositoryTest extends AbstractRepositoryTest
 {
     protected static $dbName = 'doctrine_mongodb';
+    /**
+     * @var Connection
+     */
     protected $connection;
 
     protected function createRepository()

--- a/test/Broadway/Saga/State/StateManagerTest.php
+++ b/test/Broadway/Saga/State/StateManagerTest.php
@@ -17,7 +17,17 @@ use Broadway\UuidGenerator\Testing\MockUuidGenerator;
 
 class StateManagerTest extends TestCase
 {
+    /**
+     * @var InMemoryRepository
+     */
     private $repository;
+    /**
+     * @var MockUuidGenerator
+     */
+    private $generator;
+    /**
+     * @var StateManager
+     */
     private $manager;
 
     public function setUp()

--- a/test/Broadway/Saga/StateTest.php
+++ b/test/Broadway/Saga/StateTest.php
@@ -15,6 +15,9 @@ use Broadway\TestCase;
 
 class StateTest extends TestCase
 {
+    /**
+     * @var State
+     */
     private $state;
 
     public function setUp()


### PR DESCRIPTION
It PR changes the saga implementation from using the `DomainMessage::payload` to using the `DomainMessage`. 
- This adds a BC break to `Broadway\Saga\MetadataInterface` and `Broadway\Saga\Saga` because they now expect a `Broadway\Domain\DomainMessage` (https://github.com/qandidate-labs/broadway/commit/2100d80481246ee4c1f8860382b52aa4cce81729)
- This adds a third  (`DomainMessage`) argument to the Saga method call (https://github.com/qandidate-labs/broadway/commit/7c0e0514055d902603c1ee4dc225a0190ca68c5d) to allow for acessing the DomainMessage in the handleX method.
- This adds a second (`DomainMessage`) argument to the criteria callback to allow criteria to have access to the DomainMessage (https://github.com/qandidate-labs/broadway/commit/03a54a6e40e51cdf8c0853467dbba53e4c92c4c7)
- Fixed the skipping StaticallyConfiguredSagaMetadataFactoryTest
- It also fixes some other issues like missing properties, doc blocks 

Looking forward to your feedback!
