### PR TITLE
Duplicate playhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - We moved the Symfony bundle to a [separate repository](https://github.com/broadway/broadway-bundle)
 - The DBALEventStore requires a BinaryUuidConverter
 - We moved the Saga component to a [separate repository](https://github.com/broadway/broadway-saga)
+- DBALEventStore and InMemoryEventStore can now throw DuplicatePlayheadException.
+  Ensure you are catching EventStoreException instead of specific driver exceptions.
 
 ## v0.10.x
 

--- a/src/Broadway/EventStore/DBALEventStore.php
+++ b/src/Broadway/EventStore/DBALEventStore.php
@@ -112,6 +112,7 @@ class DBALEventStore implements EventStoreInterface, EventStoreManagementInterfa
         $this->connection->beginTransaction();
 
         try {
+            /** @var DomainMessage $domainMessage */
             foreach ($eventStream as $domainMessage) {
                 $this->insertMessage($this->connection, $domainMessage);
             }
@@ -120,7 +121,7 @@ class DBALEventStore implements EventStoreInterface, EventStoreManagementInterfa
         } catch (UniqueConstraintViolationException $exception) {
             $this->connection->rollBack();
 
-            throw DuplicatePlayheadException::create($exception);
+            throw new DuplicatePlayheadException($eventStream, $exception);
         } catch (DBALException $exception) {
             $this->connection->rollBack();
 

--- a/src/Broadway/EventStore/EventStoreInterface.php
+++ b/src/Broadway/EventStore/EventStoreInterface.php
@@ -12,6 +12,7 @@
 namespace Broadway\EventStore;
 
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\EventStore\Exception\DuplicatePlayheadException;
 
 /**
  * Loads and stores events.
@@ -28,6 +29,8 @@ interface EventStoreInterface
     /**
      * @param mixed                      $id
      * @param DomainEventStreamInterface $eventStream
+     *
+     * @throws DuplicatePlayheadException
      */
     public function append($id, DomainEventStreamInterface $eventStream);
 }

--- a/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
+++ b/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Broadway\EventStore\Exception;
+
+use Broadway\EventStore\EventStoreException;
+use Exception;
+
+class DuplicatePlayheadException extends EventStoreException
+{
+    public static function create(Exception $exception)
+    {
+        return new self(null, 0, $exception);
+    }
+}

--- a/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
+++ b/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
@@ -2,13 +2,33 @@
 
 namespace Broadway\EventStore\Exception;
 
+use Broadway\Domain\DomainEventStreamInterface;
 use Broadway\EventStore\EventStoreException;
 use Exception;
 
 class DuplicatePlayheadException extends EventStoreException
 {
-    public static function create(Exception $exception)
+    /**
+     * @var DomainEventStreamInterface
+     */
+    private $eventStream;
+
+    /**
+     * @param DomainEventStreamInterface $eventStream
+     * @param Exception                  $previous
+     */
+    public function __construct(DomainEventStreamInterface $eventStream, $previous = null)
     {
-        return new self(null, 0, $exception);
+        parent::__construct(null, 0, $previous);
+
+        $this->eventStream = $eventStream;
+    }
+
+    /**
+     * @return DomainEventStreamInterface
+     */
+    public function getEventStream()
+    {
+        return $this->eventStream;
     }
 }

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -13,6 +13,7 @@ namespace Broadway\EventStore;
 
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\EventStore\Exception\DuplicatePlayheadException;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagementInterface;
 
@@ -61,7 +62,7 @@ class InMemoryEventStore implements EventStoreInterface, EventStoreManagementInt
     private function assertPlayhead($events, $playhead)
     {
         if (isset($events[$playhead])) {
-            throw new InMemoryEventStoreException(
+            throw new DuplicatePlayheadException(
                 sprintf("An event with playhead '%d' is already committed.", $playhead)
             );
         }

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -13,6 +13,7 @@ namespace Broadway\EventStore;
 
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\Exception\DuplicatePlayheadException;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagementInterface;
@@ -51,20 +52,29 @@ class InMemoryEventStore implements EventStoreInterface, EventStoreManagementInt
             $this->events[$id] = [];
         }
 
+        $this->assertStream($this->events[$id], $eventStream);
+
+        /** @var DomainMessage $event */
         foreach ($eventStream as $event) {
             $playhead = $event->getPlayhead();
-            $this->assertPlayhead($this->events[$id], $playhead);
 
             $this->events[$id][$playhead] = $event;
         }
     }
 
-    private function assertPlayhead($events, $playhead)
+    /**
+     * @param DomainMessage[]            $events
+     * @param DomainEventStreamInterface $eventsToAppend
+     */
+    private function assertStream($events, $eventsToAppend)
     {
-        if (isset($events[$playhead])) {
-            throw new DuplicatePlayheadException(
-                sprintf("An event with playhead '%d' is already committed.", $playhead)
-            );
+        /** @var DomainMessage $event */
+        foreach ($eventsToAppend as $event) {
+            $playhead = $event->getPlayhead();
+
+            if (isset($events[$playhead])) {
+                throw new DuplicatePlayheadException($eventsToAppend);
+            }
         }
     }
 

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -87,7 +87,7 @@ abstract class EventStoreTest extends TestCase
     /**
      * @test
      * @dataProvider idDataProvider
-     * @expectedException \Broadway\EventStore\EventStoreException
+     * @expectedException Broadway\EventStore\Exception\DuplicatePlayheadException
      */
     public function it_throws_an_exception_when_appending_a_duplicate_playhead($id)
     {


### PR DESCRIPTION
Allow the domain to detect race conditions on the eventstream, without depending on a driver implementation.

BC break (Documented in `CHANGELOG.md`):
If an application would catch `DBALEventStoreException` the `DuplicatePlayheadException` will be uncaught.

This can be fixed by introducing more classes and interfaces, however since we are on a 0.x release I didn't create that overhead. 

If this gets merged, people should update their code to only catch `EventStoreException`s and not the specific `DBALEventStoreException`, catching it would break the SOLID principle anyway, because you depend on implementation and not on the abstraction.

Resolves #266 
