### PR TITLE
Closure command handler

### DIFF
--- a/src/Broadway/CommandHandling/ClosureCommandHandler.php
+++ b/src/Broadway/CommandHandling/ClosureCommandHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+use Broadway\CommandHandling\Exception\ClosureParameterNotAnObjectException;
+use Broadway\CommandHandling\Exception\CommandNotAnObjectException;
+
+/**
+ * Using this class command handlers can be registered with closures
+ */
+class ClosureCommandHandler implements CommandHandler
+{
+    /**
+     * @var \Closure[]
+     */
+    private $handlers = [];
+
+    /**
+     * @param \Closure $handler
+     */
+    public function add(\Closure $handler)
+    {
+        $reflection = new \ReflectionFunction($handler);
+        $reflectionParams = $reflection->getParameters();
+
+        if(!isset($reflectionParams[0]) || !$reflectionParams[0]->getClass()) {
+            throw new ClosureParameterNotAnObjectException();
+        }
+
+        $index = $reflectionParams[0]->getClass()->getName();
+
+        $this->handlers[$index] = $handler;
+    }
+
+    /**
+     * @param mixed $command
+     */
+    public function handle($command)
+    {
+        if (!is_object($command)) {
+            throw new CommandNotAnObjectException();
+        }
+
+        $index = get_class($command);
+
+        if(!isset($this->handlers[$index])) {
+            return;
+        }
+
+        $this->handlers[$index]($command);
+    }
+}

--- a/src/Broadway/CommandHandling/Exception/ClosureParameterNotAnObjectException.php
+++ b/src/Broadway/CommandHandling/Exception/ClosureParameterNotAnObjectException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * Closure parameter should be object.
+ */
+class ClosureParameterNotAnObjectException extends InvalidArgumentException
+{
+}

--- a/test/Broadway/CommandHandling/ClosureCommandHandlerTest.php
+++ b/test/Broadway/CommandHandling/ClosureCommandHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\CommandHandling;
+
+use Broadway\CommandHandling\Exception\ClosureParameterNotAnObjectException;
+use Broadway\CommandHandling\Exception\CommandNotAnObjectException;
+use Broadway\TestCase;
+
+class ClosureCommandHandlerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_delegates_command_to_proper_handle_function()
+    {
+        $commandHandler = new ClosureCommandHandler();
+        $commandHandler->add(function (ClosureCommandHandlerTestCommand $command) {
+            $command->handle = true;
+        });
+
+        $command        = new ClosureCommandHandlerTestCommand();
+        $commandHandler->handle($command);
+
+        $this->assertTrue($command->handle);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_handling_a_non_object_command()
+    {
+        $commandHandler = new ClosureCommandHandler();
+        $this->setExpectedException(CommandNotAnObjectException::class);
+        $commandHandler->handle('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_adding_a_closure_without_an_object_argument()
+    {
+        $commandHandler = new ClosureCommandHandler();
+        $this->setExpectedException(ClosureParameterNotAnObjectException::class);
+        $commandHandler->add(function($params = null) { });
+    }
+}
+
+class ClosureCommandHandlerTestCommand
+{
+    public $handle = false;
+}


### PR DESCRIPTION
This command handler simplify the mapping of command on class. Instead of using method mapping it use closure. In this way it's also possibile to add new command handler runtime.