### PR TITLE
[RFC] SerializableReadModelInterface

### DIFF
--- a/src/Broadway/ReadModel/SerializableReadModelInterface.php
+++ b/src/Broadway/ReadModel/SerializableReadModelInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Broadway\ReadModel;
+
+use Broadway\Serializer\SerializableInterface;
+
+/**
+ * Represents a serializable read model.
+ */
+interface SerializableReadModelInterface extends SerializableInterface, ReadModelInterface
+{
+}


### PR DESCRIPTION
Most of the time you want your read model to be serializable. In fact, the ElasticSearchRepository requires the read model to be serializable when using the default serializer. Also the https://github.com/broadway/broadway/blob/master/src/Broadway/ReadModel/Testing/ReadModelTestCase.php expects the read model to be serializable.

This interface helps making both behaviours explicit.

see https://github.com/broadway/broadway/issues/172