### PR TITLE
Idempotent commands

### DIFF
--- a/src/Broadway/EventSourcing/IdempotentCommands/DuplicateCommandException.php
+++ b/src/Broadway/EventSourcing/IdempotentCommands/DuplicateCommandException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Broadway\EventSourcing\IdempotentCommands;
+
+class DuplicateCommandException extends \Exception
+{
+}

--- a/src/Broadway/EventSourcing/IdempotentCommands/IdempotentCommandStreamDecorator.php
+++ b/src/Broadway/EventSourcing/IdempotentCommands/IdempotentCommandStreamDecorator.php
@@ -1,0 +1,94 @@
+<?php
+namespace Broadway\EventSourcing\IdempotentCommands;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainEventStreamInterface;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventSourcing\EventStreamDecoratorInterface;
+use Broadway\EventStore\EventStoreInterface;
+
+class IdempotentCommandStreamDecorator implements EventStreamDecoratorInterface
+{
+    /** @var EventStoreInterface */
+    private $eventStore;
+
+    /** @var string */
+    private $metaDataKey;
+
+    /** @var string */
+    private $commandId;
+
+    /**
+     * IdempotentCommandStreamDecorator constructor.
+     *
+     * @param EventStoreInterface $eventStore
+     * @param string              $commandId
+     * @param string              $metaDataKey
+     */
+    public function __construct(EventStoreInterface $eventStore, $commandId, $metaDataKey = 'command-id')
+    {
+        $this->eventStore  = $eventStore;
+        $this->metaDataKey = $metaDataKey;
+        $this->commandId   = $commandId;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decorateForWrite($aggregateType, $aggregateIdentifier, DomainEventStreamInterface $eventStream)
+    {
+        if ($this->existsEventWithCommandId($this->commandId, $aggregateIdentifier)) {
+            throw new DuplicateCommandException('Command #'.$this->commandId.' has already been executed');
+        }
+
+        $domainMessagesWithMetaData = [];
+        /** @var DomainMessage $domainMessage */
+        foreach ($eventStream as $domainMessage) {
+            $domainMessagesWithMetaData[] = $domainMessage->andMetadata(
+                Metadata::kv($this->metaDataKey, $this->commandId));
+        }
+
+        return new DomainEventStream($domainMessagesWithMetaData);
+    }
+
+    /**
+     * @param DomainMessage $domainMessage
+     *
+     * @return string|null
+     */
+    private function getCommandId(DomainMessage $domainMessage)
+    {
+        $metaData = $domainMessage->getMetadata()
+                                  ->serialize();
+
+        // @see http://stackoverflow.com/questions/4260086/php-how-to-use-array-filter-to-filter-array-keys
+        $commandId = array_intersect_key($metaData, array_flip([$this->metaDataKey]));
+
+        if (!$commandId) {
+            return null;
+        }
+
+        return reset($commandId);
+    }
+
+    /**
+     * @param string $commandId
+     * @param string $aggregateId
+     *
+     * @return bool
+     */
+    private function existsEventWithCommandId($commandId, $aggregateId)
+    {
+        /** @var DomainMessage $domainMessage */
+        foreach ($this->eventStore->load($aggregateId) as $domainMessage) {
+            $committedCommandId = $this->getCommandId($domainMessage);
+            if ($committedCommandId == $commandId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/test/Broadway/EventSourcing/IdempotentCommands/IdempotentCommandStreamDecoratorTest.php
+++ b/test/Broadway/EventSourcing/IdempotentCommands/IdempotentCommandStreamDecoratorTest.php
@@ -1,0 +1,68 @@
+<?php
+namespace Broadway\EventSourcing\IdempotentCommands;
+
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventStore\EventStoreInterface;
+use Broadway\EventStore\InMemoryEventStore;
+use Broadway\TestCase;
+
+class IdempotentCommandStreamDecoratorTest extends TestCase
+{
+    const COMMAND_ID_META_KEY = 'command-id';
+
+    /** @var IdempotentCommandStreamDecorator */
+    private $decorator;
+    private $commandId;
+    /** @var EventStoreInterface */
+    private $eventStore;
+
+    protected function setUp()
+    {
+        $this->commandId = uniqid();
+
+        $this->eventStore = new InMemoryEventStore();
+        $this->eventStore->append('id', $this->createDomainEventStream(1));
+
+        $this->decorator = new IdempotentCommandStreamDecorator(
+            $this->eventStore, $this->commandId, self::COMMAND_ID_META_KEY);
+    }
+
+    /** @test */
+    public function it_adds_command_id_as_metadata()
+    {
+        $eventStream    = $this->createDomainEventStream(2);
+        $newEventStream = $this->decorator->decorateForWrite('type', 'id', $eventStream);
+
+        $expectedMetadata = new Metadata([self::COMMAND_ID_META_KEY => $this->commandId, 'bar' => 1337]);
+
+        /** @var DomainMessage $domainMessage */
+        foreach ($newEventStream as $domainMessage) {
+            $metadata = $domainMessage->getMetadata();
+
+            $this->assertEquals($expectedMetadata, $metadata);
+        }
+    }
+
+    /**
+     * @test
+     * @expectedException \Broadway\EventSourcing\IdempotentCommands\DuplicateCommandException
+     */
+    public function it_throws_exception_when_same_command_has_been_executed()
+    {
+        $eventStream    = $this->createDomainEventStream(2);
+        $newEventStream = $this->decorator->decorateForWrite('type', 'id', $eventStream);
+        $this->eventStore->append('id', $newEventStream);
+
+        $otherEventStream = $this->createDomainEventStream(3);
+        $this->decorator->decorateForWrite('type', 'id', $otherEventStream);
+    }
+
+    private function createDomainEventStream($playhead)
+    {
+        $m1 = DomainMessage::recordNow('id', $playhead, Metadata::kv('bar', 1337), 'payload');
+
+        return new DomainEventStream([$m1]);
+    }
+}


### PR DESCRIPTION
This PR enables Broadway users to ensure that each command is only executed once. Therefore it adds a command id to the domain messages' meta data with an event stream decorator. This command id gets transferred together with the request in a real-world app. If the same command gets executed a second time a DuplicateCommandException will be thrown.