### PR TITLE
expose playhead of EventSourcedAggregateRoot

### DIFF
--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -116,4 +116,12 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
 
         return 'apply' . end($classParts);
     }
+
+    /**
+     * @return int
+     */
+    public function getPlayhead()
+    {
+        return $this->playhead;
+    }
 }


### PR DESCRIPTION
useful for snapshotting support when you want to snapshot an aggregate root at a given playhead.

see https://github.com/broadway/broadway/issues/111