### PR TITLE
load events starting from a given playhead

### DIFF
--- a/src/Broadway/EventStore/EventStoreInterface.php
+++ b/src/Broadway/EventStore/EventStoreInterface.php
@@ -27,6 +27,12 @@ interface EventStoreInterface
     public function load($id);
 
     /**
+     * @param mixed $id
+     * @param int   $playhead
+     */
+    public function loadFromPlayhead($id, $playhead);
+
+    /**
      * @param mixed                      $id
      * @param DomainEventStreamInterface $eventStream
      *

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -44,6 +44,29 @@ class InMemoryEventStore implements EventStoreInterface, EventStoreManagementInt
     /**
      * {@inheritDoc}
      */
+    public function loadFromPlayhead($id, $playhead)
+    {
+        $id = (string) $id;
+
+        if (!isset($this->events[$id])) {
+            return new DomainEventStream([]);
+        }
+
+        return new DomainEventStream(
+            array_values(
+                array_filter(
+                    $this->events[$id],
+                    function ($event) use ($playhead) {
+                        return $playhead <= $event->getPlayhead();
+                    }
+                )
+            )
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function append($id, DomainEventStreamInterface $eventStream)
     {
         $id = (string) $id;

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -66,6 +66,14 @@ class TraceableEventStore implements EventStoreInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function loadFromPlayhead($id, $playhead)
+    {
+        return $this->eventStore->loadFromPlayhead($id, $playhead);
+    }
+
+    /**
      * Start tracing.
      */
     public function trace()


### PR DESCRIPTION
This paves the way for snapshotting support, where you want to load only the events recorded since last snapshot.

Borrowed heavily from @kimlai's PR: https://github.com/broadway/broadway/pull/147

see https://github.com/broadway/broadway/issues/111