### PR TITLE
Mark some classes with `final`

### DIFF
--- a/src/Broadway/Auditing/CommandLogger.php
+++ b/src/Broadway/Auditing/CommandLogger.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
  *
  * This object can be registered as an event listener.
  */
-class CommandLogger
+final class CommandLogger
 {
     private $logger;
     private $commandSerializer;

--- a/src/Broadway/Auditing/NullByteCommandSerializer.php
+++ b/src/Broadway/Auditing/NullByteCommandSerializer.php
@@ -17,7 +17,7 @@ namespace Broadway\Auditing;
  * There are many other ways to implement serialization on commands, but since
  * this is only for logging purposes we get away with this solution for now.
  */
-class NullByteCommandSerializer implements CommandSerializer
+final class NullByteCommandSerializer implements CommandSerializer
 {
     /**
      * {@inheritDoc}

--- a/src/Broadway/CommandHandling/EventDispatchingCommandBus.php
+++ b/src/Broadway/CommandHandling/EventDispatchingCommandBus.php
@@ -20,7 +20,7 @@ use Exception;
  * Dispatches events signalling whether a command was executed successfully or
  * if it failed.
  */
-class EventDispatchingCommandBus implements CommandBus
+final class EventDispatchingCommandBus implements CommandBus
 {
     const EVENT_COMMAND_SUCCESS = 'broadway.command_handling.command_success';
     const EVENT_COMMAND_FAILURE = 'broadway.command_handling.command_failure';

--- a/src/Broadway/CommandHandling/Exception/CommandNotAnObjectException.php
+++ b/src/Broadway/CommandHandling/Exception/CommandNotAnObjectException.php
@@ -16,6 +16,6 @@ use InvalidArgumentException;
 /**
  * Commands should be objects.
  */
-class CommandNotAnObjectException extends InvalidArgumentException
+final class CommandNotAnObjectException extends InvalidArgumentException
 {
 }

--- a/src/Broadway/CommandHandling/SimpleCommandBus.php
+++ b/src/Broadway/CommandHandling/SimpleCommandBus.php
@@ -14,7 +14,7 @@ namespace Broadway\CommandHandling;
 /**
  * Simple synchronous dispatching of commands.
  */
-class SimpleCommandBus implements CommandBus
+final class SimpleCommandBus implements CommandBus
 {
     private $commandHandlers = [];
     private $queue           = [];

--- a/src/Broadway/CommandHandling/Testing/TraceableCommandBus.php
+++ b/src/Broadway/CommandHandling/Testing/TraceableCommandBus.php
@@ -17,7 +17,7 @@ use Broadway\CommandHandling\CommandHandler;
 /**
  * Command bus that is able to record all dispatched commands.
  */
-class TraceableCommandBus implements CommandBus
+final class TraceableCommandBus implements CommandBus
 {
     private $commandHandlers = [];
     private $commands        = [];

--- a/src/Broadway/Domain/DateTime.php
+++ b/src/Broadway/Domain/DateTime.php
@@ -18,7 +18,7 @@ use DateTimeZone;
 /**
  * Immutable DateTime implementation with some helper methods.
  */
-class DateTime
+final class DateTime
 {
     const FORMAT_STRING = 'Y-m-d\TH:i:s.uP';
 

--- a/src/Broadway/Domain/DomainEventStream.php
+++ b/src/Broadway/Domain/DomainEventStream.php
@@ -17,7 +17,7 @@ use IteratorAggregate;
 /**
  * Represents a stream of DomainEventMessages in sequence.
  */
-class DomainEventStream implements IteratorAggregate
+final class DomainEventStream implements IteratorAggregate
 {
     private $events;
 

--- a/src/Broadway/Domain/Metadata.php
+++ b/src/Broadway/Domain/Metadata.php
@@ -16,7 +16,7 @@ use Broadway\Serializer\Serializable;
 /**
  * Metadata adding extra information to the DomainMessage.
  */
-class Metadata implements Serializable
+final class Metadata implements Serializable
 {
     private $values = [];
 

--- a/src/Broadway/EventDispatcher/CallableEventDispatcher.php
+++ b/src/Broadway/EventDispatcher/CallableEventDispatcher.php
@@ -14,7 +14,7 @@ namespace Broadway\EventDispatcher;
 /**
  * Event dispatcher implementation.
  */
-class CallableEventDispatcher implements EventDispatcher
+final class CallableEventDispatcher implements EventDispatcher
 {
     private $listeners = [];
 

--- a/src/Broadway/EventDispatcher/Testing/TraceableEventDispatcher.php
+++ b/src/Broadway/EventDispatcher/Testing/TraceableEventDispatcher.php
@@ -13,7 +13,7 @@ namespace Broadway\EventDispatcher\Testing;
 
 use Broadway\EventDispatcher\EventDispatcher;
 
-class TraceableEventDispatcher implements EventDispatcher
+final class TraceableEventDispatcher implements EventDispatcher
 {
     private $dispatchedEvents = [];
 

--- a/src/Broadway/EventHandling/SimpleEventBus.php
+++ b/src/Broadway/EventHandling/SimpleEventBus.php
@@ -16,7 +16,7 @@ use Broadway\Domain\DomainEventStream;
 /**
  * Simple synchronous publishing of events.
  */
-class SimpleEventBus implements EventBus
+final class SimpleEventBus implements EventBus
 {
     private $eventListeners = [];
     private $queue          = [];

--- a/src/Broadway/EventHandling/TraceableEventBus.php
+++ b/src/Broadway/EventHandling/TraceableEventBus.php
@@ -17,7 +17,7 @@ use Broadway\Domain\DomainMessage;
 /**
  * Event bus that is able to record all dispatched events.
  */
-class TraceableEventBus implements EventBus
+final class TraceableEventBus implements EventBus
 {
     private $eventBus;
     private $recorded = [];

--- a/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/NamedConstructorAggregateFactory.php
@@ -10,7 +10,7 @@ use Broadway\Domain\DomainEventStream;
  * which is itself responsible for returning an instance of itself.
  * E.g. (\Vendor\AggregateRoot::instantiateForReconstitution())->initializeState($domainEventStream);
  */
-class NamedConstructorAggregateFactory implements AggregateFactory
+final class NamedConstructorAggregateFactory implements AggregateFactory
 {
     /**
      * @var string the name of the method to call on the Aggregate

--- a/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/PublicConstructorAggregateFactory.php
@@ -9,7 +9,7 @@ use Broadway\Domain\DomainEventStream;
  * passing a DomainEventStream to the public initializeState() method.
  * E.g. (new \Vendor\AggregateRoot)->initializeState($domainEventStream);
  */
-class PublicConstructorAggregateFactory implements AggregateFactory
+final class PublicConstructorAggregateFactory implements AggregateFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Broadway/EventSourcing/AggregateRootAlreadyRegisteredException.php
+++ b/src/Broadway/EventSourcing/AggregateRootAlreadyRegisteredException.php
@@ -16,6 +16,6 @@ use RuntimeException;
 /**
  * Exception thrown when an aggregate root is already registered.
  */
-class AggregateRootAlreadyRegisteredException extends RuntimeException
+final class AggregateRootAlreadyRegisteredException extends RuntimeException
 {
 }

--- a/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
+++ b/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnrichingEventStreamDecorator.php
@@ -18,7 +18,7 @@ use Broadway\EventSourcing\EventStreamDecorator;
 /**
  * Event stream decorator that adds extra metadata.
  */
-class MetadataEnrichingEventStreamDecorator implements EventStreamDecorator
+final class MetadataEnrichingEventStreamDecorator implements EventStreamDecorator
 {
     private $metadataEnrichers;
 

--- a/src/Broadway/EventStore/CallableEventVisitor.php
+++ b/src/Broadway/EventStore/CallableEventVisitor.php
@@ -13,7 +13,7 @@ namespace Broadway\EventStore;
 
 use Broadway\Domain\DomainMessage;
 
-class CallableEventVisitor implements EventVisitor
+final class CallableEventVisitor implements EventVisitor
 {
     /**
      * @var callable

--- a/src/Broadway/EventStore/ConcurrencyConflictResolver/BlacklistConcurrencyConflictResolver.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolver/BlacklistConcurrencyConflictResolver.php
@@ -4,7 +4,7 @@ namespace Broadway\EventStore\ConcurrencyConflictResolver;
 use Broadway\Domain\DomainMessage;
 use Webmozart\Assert\Assert;
 
-class BlacklistConcurrencyConflictResolver implements ConcurrencyConflictResolver
+final class BlacklistConcurrencyConflictResolver implements ConcurrencyConflictResolver
 {
     private $conflictingEvents = [];
 

--- a/src/Broadway/EventStore/ConcurrencyConflictResolver/WhitelistConcurrencyConflictResolver.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolver/WhitelistConcurrencyConflictResolver.php
@@ -4,7 +4,7 @@ namespace Broadway\EventStore\ConcurrencyConflictResolver;
 use Broadway\Domain\DomainMessage;
 use Webmozart\Assert\Assert;
 
-class WhitelistConcurrencyConflictResolver implements ConcurrencyConflictResolver
+final class WhitelistConcurrencyConflictResolver implements ConcurrencyConflictResolver
 {
     private $independentEvents = [];
 

--- a/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
@@ -6,7 +6,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\ConcurrencyConflictResolver\ConcurrencyConflictResolver;
 use Broadway\EventStore\Exception\DuplicatePlayheadException;
 
-class ConcurrencyConflictResolvingEventStore implements EventStore
+final class ConcurrencyConflictResolvingEventStore implements EventStore
 {
     /** @var EventStore */
     private $eventStore;

--- a/src/Broadway/EventStore/EventStreamNotFoundException.php
+++ b/src/Broadway/EventStore/EventStreamNotFoundException.php
@@ -14,6 +14,6 @@ namespace Broadway\EventStore;
 /**
  * Exception thrown if an event stream is not found.
  */
-class EventStreamNotFoundException extends EventStoreException
+final class EventStreamNotFoundException extends EventStoreException
 {
 }

--- a/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
+++ b/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
@@ -6,7 +6,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\EventStore\EventStoreException;
 use Exception;
 
-class DuplicatePlayheadException extends EventStoreException
+final class DuplicatePlayheadException extends EventStoreException
 {
     /**
      * @var DomainEventStream

--- a/src/Broadway/EventStore/Exception/InvalidIdentifierException.php
+++ b/src/Broadway/EventStore/Exception/InvalidIdentifierException.php
@@ -14,6 +14,6 @@ namespace Broadway\EventStore\Exception;
 /**
  * Class InvalidIdentifierException
  */
-class InvalidIdentifierException extends \InvalidArgumentException
+final class InvalidIdentifierException extends \InvalidArgumentException
 {
 }

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -22,7 +22,7 @@ use Broadway\EventStore\Management\EventStoreManagement;
  *
  * Useful for testing code that uses an event store.
  */
-class InMemoryEventStore implements EventStore, EventStoreManagement
+final class InMemoryEventStore implements EventStore, EventStoreManagement
 {
     private $events = [];
 

--- a/src/Broadway/EventStore/Management/Criteria.php
+++ b/src/Broadway/EventStore/Management/Criteria.php
@@ -13,7 +13,7 @@ namespace Broadway\EventStore\Management;
 
 use Broadway\Domain\DomainMessage;
 
-class Criteria
+final class Criteria
 {
     private $aggregateRootTypes = [];
     private $aggregateRootIds   = [];

--- a/src/Broadway/EventStore/Management/CriteriaNotSupportedException.php
+++ b/src/Broadway/EventStore/Management/CriteriaNotSupportedException.php
@@ -21,6 +21,6 @@ namespace Broadway\EventStore\Management;
  * Class CriteriaNotSupportedException
  * @package Broadway\EventStore\Management
  */
-class CriteriaNotSupportedException extends EventStoreManagementException
+final class CriteriaNotSupportedException extends EventStoreManagementException
 {
 }

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -17,7 +17,7 @@ use Broadway\Domain\DomainMessage;
 /**
  * Event store that is able to record all appended events.
  */
-class TraceableEventStore implements EventStore
+final class TraceableEventStore implements EventStore
 {
     private $eventStore;
     private $recorded = [];

--- a/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
+++ b/src/Broadway/ReadModel/InMemory/InMemoryRepository.php
@@ -20,7 +20,7 @@ use Broadway\ReadModel\Transferable;
  *
  * The in-memory repository is useful for testing code.
  */
-class InMemoryRepository implements Repository, Transferable
+final class InMemoryRepository implements Repository, Transferable
 {
     private $data = [];
 

--- a/src/Broadway/ReadModel/InMemory/InMemoryRepositoryFactory.php
+++ b/src/Broadway/ReadModel/InMemory/InMemoryRepositoryFactory.php
@@ -16,7 +16,7 @@ use Broadway\ReadModel\RepositoryFactory;
 /**
  * Creates in-memory repositories.
  */
-class InMemoryRepositoryFactory implements RepositoryFactory
+final class InMemoryRepositoryFactory implements RepositoryFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Broadway/ReadModel/Testing/DomainMessageScenario.php
+++ b/src/Broadway/ReadModel/Testing/DomainMessageScenario.php
@@ -27,7 +27,7 @@ use PHPUnit_Framework_TestCase;
  * 2) when():  When a specific domain message is handled
  * 3) then():  The repository should contain these read models
  */
-class DomainMessageScenario
+final class DomainMessageScenario
 {
     private $testCase;
     private $projector;

--- a/src/Broadway/Repository/AggregateNotFoundException.php
+++ b/src/Broadway/Repository/AggregateNotFoundException.php
@@ -17,7 +17,7 @@ use RuntimeException;
 /**
  * Exception thrown when an aggregate is not found.
  */
-class AggregateNotFoundException extends RuntimeException
+final class AggregateNotFoundException extends RuntimeException
 {
     /**
      * @param mixed     $id

--- a/src/Broadway/Serializer/SimpleInterfaceSerializer.php
+++ b/src/Broadway/Serializer/SimpleInterfaceSerializer.php
@@ -16,7 +16,7 @@ use Assert\Assertion as Assert;
 /**
  * Serializer that serializes objects that implement a specific interface.
  */
-class SimpleInterfaceSerializer implements Serializer
+final class SimpleInterfaceSerializer implements Serializer
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
I suggest to lock some classes from inheritance before releasing 1.0.

Motivation:
* http://verraes.net/2014/05/final-classes-in-php/
* https://ocramius.github.io/blog/when-to-declare-classes-final/

In short, it is pain-free to mark as `final`:
* value objects; you don't need to mock/proxy them anyway: just create new instance of VO;
* classes with 1-to-1 interface: you always can create decorator with new behavior.

It makes easier to keep BC for your classes and forces to use composition instead of inheritance.