### PR TITLE
Add consistency to the upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,7 +57,7 @@ This is the complete list of changes:
 * Broadway/Auditing/CommandSerializer -> NullByteCommandSerializer
 * Broadway/CommandHandling/CommandHandler -> SimpleCommandHandler
 * Broadway/EventDispatcher/EventDispatcher -> CallableEventDispatcher
-* Broadway/EventSourcing/EventSourcedEntity > SimpleEventSourcedEntity
+* Broadway/EventSourcing/EventSourcedEntity -> SimpleEventSourcedEntity
 * Broadway/ReadModel/ReadModelTestCase -> SerializableReadModelTestCase
 
 ### Dropped interfaces


### PR DESCRIPTION
I've just added a hyphen but it's because i'm creating an automated script for our internal projects and this helped me parse it, and may help others. 