### PR TITLE
Remove sprintf regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ matrix:
     allow_failures:
         - php: hhvm
 
-addons:
-    apt:
-        packages:
-            - language-pack-fr
-            - language-pack-en
-
 before_install:
     # Disable XDebug speed up test execution. (Ignore failures if platform does not had the extension installed)
     - phpenv config-rm xdebug.ini || return 0

--- a/test/Broadway/Domain/DateTimeTest.php
+++ b/test/Broadway/Domain/DateTimeTest.php
@@ -28,21 +28,10 @@ class DateTimeTest extends TestCase
 
     /**
      * @test
-     * @dataProvider providesLocales
      */
-    public function it_creates_now($locale)
+    public function it_creates_now()
     {
-        $this->setLocale(LC_ALL, $locale);
-
         $this->assertInstanceOf('Broadway\Domain\DateTime', DateTime::now());
-    }
-
-    public function providesLocales()
-    {
-        return array(
-            array('en_GB.UTF-8'),
-            array('fr_FR.UTF-8'),
-        );
     }
 
     /**


### PR DESCRIPTION
By default tests fail on my machine because the France locale is not available.
Assuming the en_US locale is available on more machines than fr_FR.

This commit will resolve the following issue

```
1) Broadway\Domain\DateTimeTest::it_creates_now with data set #1 ('fr_FR.UTF-8')
PHPUnit_Framework_Exception: The locale functionality is not implemented on your platform, the specified locale does not exist or the category name is invalid.

/.../broadway/test/Broadway/Domain/DateTimeTest.php:35
```