### PR TITLE
Upgrade .php_cs file to friends-of-symfony version

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,22 +1,10 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(__DIR__)
-;
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__);
 
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->fixers(array(
-        'align_double_arrow',
-        'align_equals',
-        'concat_with_spaces',
-        'ordered_use',
-        'extra_empty_lines',
-        'phpdoc_params',
-        'remove_lines_between_uses',
-        'return',
-        'unused_use',
-        'whitespacy_lines',
-        'short_array_syntax'
-    ))
-    ->finder($finder);
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder);


### PR DESCRIPTION
Since my pre-commit hook was triggered by this outdated configuration I tried updating it. However it seems that a lot of rules changed, however I just realized while writing this I should have had a look at [UPGRADE.md](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE.md).

However, since the project is pretty opiniated on Symfony I don't think it would hurt to simply use that configuration.

If not this is how far I got in migrating the rules (without being smart enough to look at the upgrade file):
```
        '@PSR2' => true,
        'strict_param' => true,
        'array_syntax' => ['syntax' => 'short'],
        'align_double_arrow' => true,
        'align_equals' => true,
        'concat_with_spaces' => 'one',
        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
        'blank_line_before_statement' => ['return', 'throw', 'continue', 'declare', 'try'],
        'phpdoc_align' => ['param', 'return', 'throws', 'type', 'var'],
        'no_leading_import_slash' => true,
```