### PR TITLE
Provide access to Metadata values with `get()` and `all()`

### DIFF
--- a/src/Broadway/Domain/Metadata.php
+++ b/src/Broadway/Domain/Metadata.php
@@ -29,6 +29,19 @@ class Metadata implements Serializable
     }
 
     /**
+     * Helper method to construct an instance containing the key and value.
+     *
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return Metadata
+     */
+    public static function kv($key, $value)
+    {
+        return new Metadata([$key => $value]);
+    }
+
+    /**
      * Merges the values of this and the other instance.
      *
      * @param Metadata $otherMetadata
@@ -43,24 +56,37 @@ class Metadata implements Serializable
     }
 
     /**
-     * {@inheritDoc}
+     * Returns an array with all metadata.
+     *
+     * @return array
      */
-    public function serialize()
+    public function all()
     {
         return $this->values;
     }
 
     /**
-     * Helper method to construct an instance containing the key and value.
+     * Get a specific metadata value based on key.
      *
-     * @param mixed $key
-     * @param mixed $value
+     * @param string $key
      *
-     * @return Metadata
+     * @return mixed
      */
-    public static function kv($key, $value)
+    public function get($key)
     {
-        return new Metadata([$key => $value]);
+        if (!array_key_exists($key, $this->values)) {
+            return null;
+        }
+
+        return $this->values[$key];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function serialize()
+    {
+        return $this->values;
     }
 
     /**

--- a/test/Broadway/Domain/MetadataTest.php
+++ b/test/Broadway/Domain/MetadataTest.php
@@ -49,4 +49,36 @@ class MetadataTest extends TestCase
         $expected = new Metadata(['foo' => 42]);
         $this->assertEquals($expected, $m1);
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_all_values()
+    {
+        $m1 = new Metadata(['foo' => 42, 'bar' => 1337]);
+
+        $expected = ['foo' => 42, 'bar' => 1337];
+        $this->assertEquals($expected, $m1->all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_when_get_contains_unset_key()
+    {
+        $m1 = new Metadata(['foo' => 42]);
+
+        $this->assertNull($m1->get('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_value_of_a_key_with_get()
+    {
+        $m1 = new Metadata(['foo' => 42]);
+
+        $expected = 42;
+        $this->assertEquals($expected, $m1->get('foo'));
+    }
 }


### PR DESCRIPTION
Before this commit it wasn't possible to read values from Metadata except when you serialized it.

Eventhough `serialize()` is functionally equal to `all()` it was decided at #318 to add it for semantics sake. In other words, `serialize()` must be used for persisting the Metadata, `all()` or `get()` must be used to act upon.