### PR TITLE
[POC|WIP] Ability to detect event sequence

### DIFF
--- a/src/Broadway/Domain/DomainMessage.php
+++ b/src/Broadway/Domain/DomainMessage.php
@@ -34,7 +34,7 @@ final class DomainMessage
     /**
      * @var string
      */
-    private $id;
+    private $aggregateId;
 
     /**
      * @var DateTime
@@ -42,27 +42,27 @@ final class DomainMessage
     private $recordedOn;
 
     /**
-     * @param string   $id
+     * @param string   $aggregateId
      * @param int      $playhead
      * @param Metadata $metadata
      * @param mixed    $payload
      * @param DateTime $recordedOn
      */
-    public function __construct($id, $playhead, Metadata $metadata, $payload, DateTime $recordedOn)
+    public function __construct($aggregateId, $playhead, Metadata $metadata, $payload, DateTime $recordedOn)
     {
-        $this->id         = $id;
-        $this->playhead   = $playhead;
-        $this->metadata   = $metadata;
-        $this->payload    = $payload;
+        $this->aggregateId = $aggregateId;
+        $this->playhead = $playhead;
+        $this->metadata = $metadata;
+        $this->payload = $payload;
         $this->recordedOn = $recordedOn;
     }
 
     /**
      * @return string
      */
-    public function getId()
+    public function getAggregateId()
     {
-        return $this->id;
+        return $this->aggregateId;
     }
 
     /**
@@ -106,16 +106,16 @@ final class DomainMessage
     }
 
     /**
-     * @param string   $id
+     * @param string   $aggregateId
      * @param int      $playhead
      * @param Metadata $metadata
      * @param mixed    $payload
      *
      * @return DomainMessage
      */
-    public static function recordNow($id, $playhead, Metadata $metadata, $payload)
+    public static function recordNow($aggregateId, $playhead, Metadata $metadata, $payload)
     {
-        return new DomainMessage($id, $playhead, $metadata, $payload, DateTime::now());
+        return new DomainMessage($aggregateId, $playhead, $metadata, $payload, DateTime::now());
     }
 
     /**
@@ -127,8 +127,9 @@ final class DomainMessage
      */
     public function andMetadata(Metadata $metadata)
     {
-        $newMetadata = $this->metadata->merge($metadata);
+        $domainMessage = clone $this;
+        $domainMessage->metadata = $this->metadata->merge($metadata);
 
-        return new DomainMessage($this->id, $this->playhead, $newMetadata, $this->payload, $this->recordedOn);
+        return $domainMessage;
     }
 }

--- a/src/Broadway/Domain/DomainMessage.php
+++ b/src/Broadway/Domain/DomainMessage.php
@@ -19,6 +19,11 @@ final class DomainMessage
     /**
      * @var int
      */
+    private $sequenceId;
+
+    /**
+     * @var int
+     */
     private $playhead;
 
     /**
@@ -55,6 +60,14 @@ final class DomainMessage
         $this->metadata = $metadata;
         $this->payload = $payload;
         $this->recordedOn = $recordedOn;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getSequenceId()
+    {
+        return $this->sequenceId;
     }
 
     /**
@@ -116,6 +129,19 @@ final class DomainMessage
     public static function recordNow($aggregateId, $playhead, Metadata $metadata, $payload)
     {
         return new DomainMessage($aggregateId, $playhead, $metadata, $payload, DateTime::now());
+    }
+
+    /**
+     * @param int $sequenceId
+     *
+     * @return DomainMessage
+     */
+    public function withSequenceId($sequenceId)
+    {
+        $domainMessage = clone $this;
+        $domainMessage->sequenceId = $sequenceId;
+
+        return $domainMessage;
     }
 
     /**

--- a/src/Broadway/Domain/DomainMessage.php
+++ b/src/Broadway/Domain/DomainMessage.php
@@ -58,7 +58,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     public function getId()
     {
@@ -66,7 +66,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return int
      */
     public function getPlayhead()
     {
@@ -74,7 +74,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return Metadata
      */
     public function getMetadata()
     {
@@ -82,7 +82,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return mixed
      */
     public function getPayload()
     {
@@ -90,7 +90,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return DateTime
      */
     public function getRecordedOn()
     {
@@ -98,7 +98,7 @@ final class DomainMessage
     }
 
     /**
-     * {@inheritDoc}
+     * @return string
      */
     public function getType()
     {

--- a/src/Broadway/EventStore/Management/Criteria.php
+++ b/src/Broadway/EventStore/Management/Criteria.php
@@ -115,7 +115,7 @@ final class Criteria
             );
         }
 
-        if ($this->aggregateRootIds && ! in_array($domainMessage->getId(), $this->aggregateRootIds)) {
+        if ($this->aggregateRootIds && ! in_array($domainMessage->getAggregateId(), $this->aggregateRootIds)) {
             return false;
         }
 

--- a/src/Broadway/EventStore/Management/EventStoreManagement.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagement.php
@@ -16,4 +16,6 @@ use Broadway\EventStore\EventVisitor;
 interface EventStoreManagement
 {
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor);
+
+    public function replayEventsBetween($lastKnownSequenceId, $sequenceIdTryingToApply, EventVisitor $eventVisitor);
 }

--- a/test/Broadway/Domain/DomainMessageTest.php
+++ b/test/Broadway/Domain/DomainMessageTest.php
@@ -28,7 +28,7 @@ class DomainMessageTest extends TestCase
 
         $domainMessage = DomainMessage::recordNow($id, $playhead, $metadata, $payload);
 
-        $this->assertEquals($id,       $domainMessage->getId());
+        $this->assertEquals($id,       $domainMessage->getAggregateId());
         $this->assertEquals($payload,  $domainMessage->getPayload());
         $this->assertEquals($playhead, $domainMessage->getPlayhead());
         $this->assertEquals($metadata, $domainMessage->getMetadata());
@@ -55,7 +55,7 @@ class DomainMessageTest extends TestCase
 
         $newMessage = $domainMessage->andMetadata(Metadata::kv('foo', 42));
 
-        $this->assertSame($domainMessage->getId(), $newMessage->getId());
+        $this->assertSame($domainMessage->getAggregateId(), $newMessage->getAggregateId());
         $this->assertSame($domainMessage->getPlayhead(), $newMessage->getPlayhead());
         $this->assertSame($domainMessage->getPayload(), $newMessage->getPayload());
         $this->assertSame($domainMessage->getRecordedOn(), $newMessage->getRecordedOn());

--- a/test/Broadway/EventStore/Management/EventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/EventStoreManagementTest.php
@@ -122,7 +122,7 @@ abstract class EventStoreManagementTest extends TestCase
     private function createAndInsertEventFixtures()
     {
         foreach ($this->getEventFixtures() as $domainMessage) {
-            $this->eventStore->append($domainMessage->getId(), new DomainEventStream([$domainMessage]));
+            $this->eventStore->append($domainMessage->getAggregateId(), new DomainEventStream([$domainMessage]));
         }
     }
 
@@ -197,7 +197,7 @@ abstract class EventStoreManagementTest extends TestCase
         $eventsByAggregateTypeAndId = [];
         foreach ($events as $event) {
             $type = $event->getType();
-            $id   = $event->getId();
+            $id   = $event->getAggregateId();
 
             if (! array_key_exists($type, $eventsByAggregateTypeAndId)) {
                 $eventsByAggregateTypeAndId[$type] = [];


### PR DESCRIPTION
Hi,

I was playing around to find a structural way of being able to guarantee an event message is delivered in order and only once when applying them asynchronously. However `DomainMessage` does not contain the information required to create such a system.

Therefore I added the sequenceId to the DomainMessage. It cannot be added to the constructor, because DBAL would only have the sequenceId after inserting the DomainMessage.

Before merging I would still need to write tests for this. 

I have the following questions:

1) Does the broadway team like the way sequence is implemented in `DomainMessage`
2) Should we use the visitEvents construction, or create a separate method drivers are already forced to be ["complex"](https://github.com/broadway/event-store-dbal/blob/master/src/DBALEventStore.php#L294) (Separate method `EventStoreManagement::replayEventsBetween` in this PR)

Please let me know if the idea is clear, otherwise I can share the code I planned for a future PR for this to maybe make more sense.

Related docs:
- http://www.axonframework.org/apidocs/2.0/org/axonframework/domain/DomainEventMessage.html#getSequenceNumber()
- https://docs.axonframework.org/v/3.0/part3/event-processing.html#asynchronous-event-processing

Edit:
After discussing with wjzijderveld it seems I misinterpreted the use of sequence. Going to have a good night sleep over this :).