### PR TITLE
Add chance to append an event stream of events with different id

### DIFF
--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -68,33 +68,33 @@ final class InMemoryEventStore implements EventStore, EventStoreManagement
      */
     public function append($id, DomainEventStream $eventStream)
     {
-        $id = (string) $id;
-
-        if (! isset($this->events[$id])) {
-            $this->events[$id] = [];
-        }
-
-        $this->assertStream($this->events[$id], $eventStream);
+        $this->assertStream($this->events, $eventStream);
 
         /** @var DomainMessage $event */
         foreach ($eventStream as $event) {
             $playhead = $event->getPlayhead();
+            $id       = (string)$event->getId();
+
+            if (!isset($this->events[$id])) {
+                $this->events[$id] = [];
+            }
 
             $this->events[$id][$playhead] = $event;
         }
     }
 
     /**
-     * @param DomainMessage[]   $events
+     * @param DomainMessage[] $events
      * @param DomainEventStream $eventsToAppend
      */
     private function assertStream($events, $eventsToAppend)
     {
         /** @var DomainMessage $event */
         foreach ($eventsToAppend as $event) {
+            $id       = (string)$event->getId();
             $playhead = $event->getPlayhead();
 
-            if (isset($events[$playhead])) {
+            if (isset($events[$id][$playhead])) {
                 throw new DuplicatePlayheadException($eventsToAppend);
             }
         }

--- a/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/EventSourcingRepositoryTest.php
@@ -48,7 +48,7 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
         // make sure events exist in the event store
         $id = 'y0l0';
         $this->eventStore->append($id, new DomainEventStream([
-            DomainMessage::recordNow(42, 0, new Metadata([]), new DidEvent())
+            DomainMessage::recordNow($id, 0, new Metadata([]), new DidEvent())
         ]));
 
         $repository = $this->repositoryWithStaticAggregateFactory();
@@ -71,7 +71,7 @@ class EventSourcingRepositoryTest extends AbstractEventSourcingRepositoryTest
         // make sure events exist in the event store
         $id = 'y0l0';
         $this->eventStore->append($id, new DomainEventStream([
-            DomainMessage::recordNow(42, 0, new Metadata([]), new DidEvent())
+            DomainMessage::recordNow($id, 0, new Metadata([]), new DidEvent())
         ]));
 
         $repository = $this->repositoryWithStaticAggregateFactory('someUnknownStaticmethod');

--- a/test/Broadway/EventStore/EventStoreTest.php
+++ b/test/Broadway/EventStore/EventStoreTest.php
@@ -161,6 +161,34 @@ abstract class EventStoreTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function it_appends_event_stream_of_events_with_different_id()
+    {
+        $dateTime          = DateTime::fromString('2014-03-12T14:17:19.176169+00:00');
+        $domainEventStream = new DomainEventStream([
+            $this->createDomainMessage(1, 0, $dateTime),
+            $this->createDomainMessage(1, 1, $dateTime),
+            $this->createDomainMessage(2, 0, $dateTime),
+            $this->createDomainMessage(2, 1, $dateTime),
+        ]);
+
+        $this->eventStore->append(null, $domainEventStream);
+
+        $expected = new DomainEventStream([
+            $this->createDomainMessage(1, 0, $dateTime),
+            $this->createDomainMessage(1, 1, $dateTime),
+        ]);
+        $this->assertEquals($expected, $this->eventStore->load(1));
+
+        $expected = new DomainEventStream([
+            $this->createDomainMessage(2, 0, $dateTime),
+            $this->createDomainMessage(2, 1, $dateTime),
+        ]);
+        $this->assertEquals($expected, $this->eventStore->load(2));
+    }
+
     public function idDataProvider()
     {
         return [


### PR DESCRIPTION
Sometimes it could be useful to append on event store in a single transaction a domain stream of events with different id. DBALEventStore don't depend on append $id.