### PR TITLE
Moved generic test classes to main namespace

### DIFF
--- a/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
@@ -9,19 +9,25 @@
  * file that was distributed with this source code.
  */
 
-namespace Broadway\ReadModel;
+namespace Broadway\ReadModel\Testing;
 
-use Broadway\TestCase;
+use Broadway\ReadModel\Repository;
 
-abstract class RepositoryTestCase extends TestCase
+abstract class RepositoryTestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Repository
+     */
     protected $repository;
-
+  
     public function setUp()
     {
         $this->repository = $this->createRepository();
     }
 
+    /**
+     * @returns Repository
+     */
     abstract protected function createRepository();
 
     /**

--- a/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Broadway\ReadModel;
+namespace Broadway\ReadModel\Testing;
+
+use Broadway\ReadModel\SerializableReadModel;
 
 class RepositoryTestReadModel implements SerializableReadModel
 {

--- a/test/Broadway/ReadModel/InMemory/InMemoryRepositoryTest.php
+++ b/test/Broadway/ReadModel/InMemory/InMemoryRepositoryTest.php
@@ -11,8 +11,8 @@
 
 namespace Broadway\ReadModel\InMemory;
 
-use Broadway\ReadModel\RepositoryTestCase;
-use Broadway\ReadModel\RepositoryTestReadModel;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\ReadModel\Testing\RepositoryTestCase;
 
 class InMemoryRepositoryTest extends RepositoryTestCase
 {


### PR DESCRIPTION
To have some "generic" test cases that can be used in the elasticsearch and mongodb implementations, it would be nice to have this testcase classes moved to the src directory.