### PR TITLE
Strip leading slash to allow testing repository with class keyword

### DIFF
--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -146,7 +146,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $lastCall = $this->eventStreamDecorator->getLastCall();
 
         $this->assertEquals($aggregate->getAggregateRootId(), $lastCall['aggregateIdentifier']);
-        $this->assertEquals(get_class($aggregate), $this->stripLeadingSlash($lastCall['aggregateType']));
+        $this->assertInstanceOf($lastCall['aggregateType'], $aggregate);
 
         $events = iterator_to_array($lastCall['eventStream']);
         $this->assertCount(1, $events);

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -146,7 +146,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
         $lastCall = $this->eventStreamDecorator->getLastCall();
 
         $this->assertEquals($aggregate->getAggregateRootId(), $lastCall['aggregateIdentifier']);
-        $this->assertEquals('\\'.get_class($aggregate), $lastCall['aggregateType']);
+        $this->assertEquals(get_class($aggregate), $this->stripLeadingSlash($lastCall['aggregateType']));
 
         $events = iterator_to_array($lastCall['eventStream']);
         $this->assertCount(1, $events);
@@ -190,6 +190,16 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
      * @return EventSourcedAggregateRoot
      */
     abstract protected function createAggregate();
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    private function stripLeadingSlash(string $value): string
+    {
+        return ($value[0] === '\\') ? substr($value, 1) : $value;
+    }
 }
 
 class DidNumberEvent

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -190,16 +190,6 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
      * @return EventSourcedAggregateRoot
      */
     abstract protected function createAggregate();
-
-    /**
-     * @param string $value
-     *
-     * @return string
-     */
-    private function stripLeadingSlash(string $value): string
-    {
-        return ($value[0] === '\\') ? substr($value, 1) : $value;
-    }
 }
 
 class DidNumberEvent


### PR DESCRIPTION
When testing a repository that has the `::class` keyword instead of a string representation, a test failed because that expected a leading slash.

The fix allows for both FQN with and without leading slash so it is BC

Thanks @reenl for helping me out!