### PR TITLE
PHPUnit 6 fixes

### DIFF
--- a/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
+++ b/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
@@ -19,7 +19,7 @@ use Broadway\EventHandling\SimpleEventBus;
 use Broadway\EventStore\EventStore;
 use Broadway\EventStore\InMemoryEventStore;
 use Broadway\EventStore\TraceableEventStore;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case that can be used to set up a command handler scenario.

--- a/src/Broadway/CommandHandling/Testing/Scenario.php
+++ b/src/Broadway/CommandHandling/Testing/Scenario.php
@@ -18,7 +18,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventStore\TraceableEventStore;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Helper testing scenario to test command handlers.
@@ -38,7 +38,7 @@ class Scenario
     private $aggregateId;
 
     public function __construct(
-        PHPUnit_Framework_TestCase $testCase,
+        TestCase $testCase,
         TraceableEventStore $eventStore,
         CommandHandler $commandHandler
     ) {

--- a/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
+++ b/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
@@ -15,7 +15,7 @@ namespace Broadway\EventSourcing\Testing;
 
 use Broadway\EventSourcing\AggregateFactory\AggregateFactory;
 use Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case that can be used to set up a command handler scenario.

--- a/src/Broadway/EventSourcing/Testing/Scenario.php
+++ b/src/Broadway/EventSourcing/Testing/Scenario.php
@@ -17,7 +17,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventSourcing\AggregateFactory\AggregateFactory;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Helper testing scenario to test command event sourced aggregate roots.
@@ -39,11 +39,11 @@ class Scenario
     private $aggregateId;
 
     /**
-     * @param PHPUnit_Framework_TestCase $testCase
-     * @param AggregateFactory           $factory
-     * @param string                     $aggregateRootClass
+     * @param TestCase         $testCase
+     * @param AggregateFactory $factory
+     * @param string           $aggregateRootClass
      */
-    public function __construct(PHPUnit_Framework_TestCase $testCase, AggregateFactory $factory, string $aggregateRootClass)
+    public function __construct(TestCase $testCase, AggregateFactory $factory, string $aggregateRootClass)
     {
         $this->testCase = $testCase;
         $this->factory = $factory;

--- a/src/Broadway/ReadModel/Testing/DomainMessageScenario.php
+++ b/src/Broadway/ReadModel/Testing/DomainMessageScenario.php
@@ -17,7 +17,7 @@ use Assert\Assertion;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventHandling\EventListener;
 use Broadway\ReadModel\Repository;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Helper testing scenario to test projects.
@@ -36,7 +36,7 @@ final class DomainMessageScenario
     private $repository;
 
     public function __construct(
-        PHPUnit_Framework_TestCase $testCase,
+        TestCase $testCase,
         Repository $repository,
         EventListener $projector
     ) {

--- a/src/Broadway/ReadModel/Testing/ProjectorScenarioTestCase.php
+++ b/src/Broadway/ReadModel/Testing/ProjectorScenarioTestCase.php
@@ -15,7 +15,7 @@ namespace Broadway\ReadModel\Testing;
 
 use Broadway\ReadModel\InMemory\InMemoryRepository;
 use Broadway\ReadModel\Projector;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case that can be used to set up a projector scenario.

--- a/src/Broadway/ReadModel/Testing/Scenario.php
+++ b/src/Broadway/ReadModel/Testing/Scenario.php
@@ -18,7 +18,7 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventHandling\EventListener;
 use Broadway\ReadModel\Repository;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Helper testing scenario to test projects.
@@ -40,7 +40,7 @@ class Scenario
     private $dateTimeGenerator;
 
     public function __construct(
-        PHPUnit_Framework_TestCase $testCase,
+        TestCase $testCase,
         Repository $repository,
         EventListener $projector
     ) {

--- a/src/Broadway/ReadModel/Testing/SerializableReadModelTestCase.php
+++ b/src/Broadway/ReadModel/Testing/SerializableReadModelTestCase.php
@@ -16,7 +16,7 @@ namespace Broadway\ReadModel\Testing;
 use Broadway\ReadModel\SerializableReadModel;
 use Broadway\Serializer\Serializable;
 use Broadway\Serializer\SimpleInterfaceSerializer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case that can be used to test a serializable read model.

--- a/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
+++ b/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
@@ -15,7 +15,7 @@ namespace Broadway\Serializer\Testing;
 
 use Broadway\Serializer\Serializable;
 use Broadway\Serializer\SimpleInterfaceSerializer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Helper to test if events implement the Serializable contract.


### PR DESCRIPTION
All Broadway test classes are still inheriting from `PHPUnit_Framework_TestCase`. This breaks all project-related tests - sorry for that! This PR will fix it.

I create a new PR to add tests to avoid these issues in the future.