### PR TITLE
Moved generic test classes to main namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [b21c245](http://github.com/broadway/broadway/commit/b21c245f4788c62df4fa5200e2f313481521a589) Provide access to Metadata values (Reen Lokum)
 * [05e88ce](http://github.com/broadway/broadway/commit/05e88ce83837bea224b65df70f9ebceebd39ed90) Moved to Symfony coding standards (Reen Lokum)
 * [df69c8d](http://github.com/broadway/broadway/commit/df69c8d1996fcb9786635ef7bfadb4873c9be3cd) Added reflection serializer (Alexander Bachmann)
+* [8486286](http://github.com/broadway/broadway/commit/848628664e61faaced00bc41926989c63c76e8e7) moved RepositoryTestCase, EventStoreTest, EventStoreManagementTest to Testing namespace (Robin van der Vleuten)
 
 ## v1.0.x
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade to 2.0
 
-## Concrete classes are made final.
+## Concrete classes are made final
 
 As it is no longer possible to extend these classes it is necessary to use composition for code reuse.
 
@@ -12,6 +12,11 @@ these interfaces the method signatures must adhere to the parent's signatures.
 ## PHPUnit 6
 PHPUnit is required when you use Broadway's test helpers like Scenarios and base test cases in
 the `src/*/Testing/*` directories. In this case you will need to update your projects to PHPUnit 6.
+
+## Test helpers
+The RepositoryTestCase, EventStoreTest, EventStoreManagementTest are moved from `test` to `src` and into
+the `Testing` namespace. It's now easier to use them without autoloading magic but you need to reimport
+the classes with the updated namespace in your project.
 
 # Upgrade to 1.0
 

--- a/src/Broadway/EventStore/Management/Testing/EventStoreManagementTest.php
+++ b/src/Broadway/EventStore/Management/Testing/EventStoreManagementTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Broadway\EventStore\Management;
+namespace Broadway\EventStore\Management\Testing;
 
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainEventStream;
@@ -19,6 +19,8 @@ use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventStore\EventStore;
 use Broadway\EventStore\EventVisitor;
+use Broadway\EventStore\Management\Criteria;
+use Broadway\EventStore\Management\CriteriaNotSupportedException;
 use Broadway\Serializer\Serializable;
 use PHPUnit\Framework\TestCase;
 
@@ -90,8 +92,8 @@ abstract class EventStoreManagementTest extends TestCase
     {
         $visitedEvents = $this->visitEvents(Criteria::create()
             ->withEventTypes([
-                'Broadway.EventStore.Management.Start',
-                'Broadway.EventStore.Management.End',
+                'Broadway.EventStore.Management.Testing.Start',
+                'Broadway.EventStore.Management.Testing.End',
             ])
         );
 
@@ -114,10 +116,10 @@ abstract class EventStoreManagementTest extends TestCase
     {
         $this->expectException(CriteriaNotSupportedException::class);
 
-        $visitedEvents = $this->visitEvents(Criteria::create()
+        $this->visitEvents(Criteria::create()
             ->withAggregateRootTypes([
-                'Broadway.EventStore.Management.AggregateTypeOne',
-                'Broadway.EventStore.Management.AggregateTypeTwo',
+                'Broadway.EventStore.Management.Testing.AggregateTypeOne',
+                'Broadway.EventStore.Management.Testing.AggregateTypeTwo',
             ])
         );
     }

--- a/src/Broadway/EventStore/Testing/EventStoreTest.php
+++ b/src/Broadway/EventStore/Testing/EventStoreTest.php
@@ -11,17 +11,18 @@
 
 declare(strict_types=1);
 
-namespace Broadway\EventStore;
+namespace Broadway\EventStore\Testing;
 
 use Broadway\Domain\DateTime;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use Broadway\EventStore\EventStreamNotFoundException;
 use Broadway\EventStore\Exception\DuplicatePlayheadException;
 use Broadway\Serializer\Serializable;
-use PHPUnit\Framework\TestCase;
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
 use PHPUnit\Framework\Error\Error;
+use PHPUnit\Framework\TestCase;
 
 abstract class EventStoreTest extends TestCase
 {

--- a/src/Broadway/EventStore/Testing/EventStoreTest.php
+++ b/src/Broadway/EventStore/Testing/EventStoreTest.php
@@ -96,12 +96,12 @@ abstract class EventStoreTest extends TestCase
      */
     public function it_throws_an_exception_when_appending_a_duplicate_playhead($id)
     {
-        $eventStream = new DomainEventStream([$this->createDomainMessage(42, 0)]);
+        $eventStream = new DomainEventStream([$this->createDomainMessage($id, 0)]);
 
         $this->expectException(DuplicatePlayheadException::class);
 
-        $this->eventStore->append(42, $eventStream);
-        $this->eventStore->append(42, $eventStream);
+        $this->eventStore->append($id, $eventStream);
+        $this->eventStore->append($id, $eventStream);
     }
 
     /**

--- a/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
@@ -11,8 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Broadway\ReadModel;
+namespace Broadway\ReadModel\Testing;
 
+use Broadway\ReadModel\Repository;
 use PHPUnit\Framework\TestCase;
 
 abstract class RepositoryTestCase extends TestCase

--- a/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
@@ -11,7 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Broadway\ReadModel;
+namespace Broadway\ReadModel\Testing;
+
+use Broadway\ReadModel\SerializableReadModel;
 
 class RepositoryTestReadModel implements SerializableReadModel
 {

--- a/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
+++ b/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
@@ -7,6 +7,7 @@ namespace Broadway\EventStore;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\ConcurrencyConflictResolver\ConcurrencyConflictResolver;
+use Broadway\EventStore\Testing\EventStoreTest;
 use Prophecy\Argument;
 
 class ConflictResolvingEventStoreTest extends EventStoreTest

--- a/test/Broadway/EventStore/InMemoryEventStoreTest.php
+++ b/test/Broadway/EventStore/InMemoryEventStoreTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Broadway\EventStore;
 
+use Broadway\EventStore\Testing\EventStoreTest;
+
 class InMemoryEventStoreTest extends EventStoreTest
 {
     protected function setUp()

--- a/test/Broadway/EventStore/Management/InMemoryEventStoreManagementTest.php
+++ b/test/Broadway/EventStore/Management/InMemoryEventStoreManagementTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Broadway\EventStore\Management;
 
 use Broadway\EventStore\InMemoryEventStore;
+use Broadway\EventStore\Management\Testing\EventStoreManagementTest;
 
 class InMemoryEventStoreManagementTest extends EventStoreManagementTest
 {

--- a/test/Broadway/ReadModel/InMemory/InMemoryRepositoryTest.php
+++ b/test/Broadway/ReadModel/InMemory/InMemoryRepositoryTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Broadway\ReadModel\InMemory;
 
 use Broadway\ReadModel\Repository;
-use Broadway\ReadModel\RepositoryTestCase;
-use Broadway\ReadModel\RepositoryTestReadModel;
+use Broadway\ReadModel\Testing\RepositoryTestCase;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
 
 class InMemoryRepositoryTest extends RepositoryTestCase
 {
@@ -44,7 +44,7 @@ class InMemoryRepositoryTest extends RepositoryTestCase
         $this->assertEquals($targetRepository->findAll(), $repository->findAll());
     }
 
-    private function createReadModel($id, $name, $foo, array $array = [])
+    private function createReadModel($id, $name, $foo, array $array = []): RepositoryTestReadModel
     {
         return new RepositoryTestReadModel($id, $name, $foo, $array);
     }


### PR DESCRIPTION
fixes https://github.com/broadway/broadway/pull/327

sorry @robinvdvleuten for hijacking your PR!

todo:
- [x] Broadway\ReadModel\Testing\RepositoryTestCase
- [x] Broadway\EventStore\Testing\EventStoreTest
- [x] Broadway\EventStore\Management\Testing\EventStoreManagementTest
- [x] update CHANGELOG.md, UPGRADE.md (depends https://github.com/broadway/broadway/pull/335)

update dependencies:
- [x] https://github.com/broadway/event-store-dbal/pull/13
- [x] https://github.com/broadway/read-model-mongodb/pull/3
- [x] https://github.com/broadway/event-store-mongodb/pull/7
- [x] https://github.com/broadway/read-model-elasticsearch/pull/6
