### PR TITLE
test: strictly encode & decode event payload

### DIFF
--- a/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
+++ b/src/Broadway/Serializer/Testing/SerializableEventTestCase.php
@@ -39,6 +39,8 @@ abstract class SerializableEventTestCase extends TestCase
         $event = $this->createEvent();
 
         $serialized = $serializer->serialize($event);
+        $serialized['payload'] = json_decode(json_encode($serialized['payload']), true);
+
         $deserialized = $serializer->deserialize($serialized);
 
         $this->assertEquals($event, $deserialized);


### PR DESCRIPTION
I noticed this test passed while deserialize() did not properly return the same object.
Typehinted parameters were ignored because everything is handled in the same request.
![image](https://user-images.githubusercontent.com/6044164/33599721-47a77df6-d9a7-11e7-8628-2985e4aa3df3.png)

Explicitly encoding/decoding the payload detects this bug