### PR TITLE
Bugfixes in event-sourced-domain-with-tests

### DIFF
--- a/examples/event-sourced-child-entity/Parts.php
+++ b/examples/event-sourced-child-entity/Parts.php
@@ -30,7 +30,7 @@ class Part extends Broadway\EventSourcing\EventSourcedAggregateRoot
      *
      * @return string
      */
-    public function getAggregateRootId()
+    public function getAggregateRootId(): string
     {
         return $this->partId;
     }
@@ -55,7 +55,7 @@ class Part extends Broadway\EventSourcing\EventSourcedAggregateRoot
         );
     }
 
-    protected function getChildEntities()
+    protected function getChildEntities(): array
     {
         // Since the aggregate root always handles the events first we can rely
         // on $this->manufacturer being set by the time the child entities are

--- a/examples/event-sourced-child-entity/PartsTest.php
+++ b/examples/event-sourced-child-entity/PartsTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Broadway\CommandHandling\CommandHandler;
+
 require_once __DIR__.'/Parts.php';
 
 /**
@@ -24,7 +26,7 @@ class PartsCommandHandlerTest extends Broadway\CommandHandling\Testing\CommandHa
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus)
+    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus): CommandHandler
     {
         $repository = new PartRepository($eventStore, $eventBus);
 

--- a/examples/event-sourced-domain-with-tests/InvitationCommandHandlerTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitationCommandHandlerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Broadway\CommandHandling\CommandHandler;
+
 require_once __DIR__.'/Invites.php';
 
 /**
@@ -24,7 +26,7 @@ class InvitationCommandHandlerTest extends Broadway\CommandHandling\Testing\Comm
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus)
+    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus): CommandHandler
     {
         $repository = new InvitationRepository($eventStore, $eventBus);
 

--- a/examples/event-sourced-domain-with-tests/Invites.php
+++ b/examples/event-sourced-domain-with-tests/Invites.php
@@ -34,7 +34,7 @@ class Invitation extends Broadway\EventSourcing\EventSourcedAggregateRoot
      *
      * {@inheritdoc}
      */
-    public function getAggregateRootId()
+    public function getAggregateRootId() : string
     {
         return $this->invitationId;
     }

--- a/examples/event-sourced-domain-with-tests/Invites.php
+++ b/examples/event-sourced-domain-with-tests/Invites.php
@@ -34,7 +34,7 @@ class Invitation extends Broadway\EventSourcing\EventSourcedAggregateRoot
      *
      * {@inheritdoc}
      */
-    public function getAggregateRootId() : string
+    public function getAggregateRootId(): string
     {
         return $this->invitationId;
     }

--- a/examples/event-sourced-domain-with-tests/InvitesTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitesTest.php
@@ -13,7 +13,7 @@ require_once __DIR__.'/Invites.php';
  * - Third, the outcome is asserted. This can either be 1) some events are
  *   recorded, or 2) an exception is thrown.
  */
-class InvitationTest extends Broadway\EventSourcing\Testing\AggregateRootScenarioTestCase
+class InvitesTest extends Broadway\EventSourcing\Testing\AggregateRootScenarioTestCase
 {
     private $generator;
 
@@ -23,7 +23,7 @@ class InvitationTest extends Broadway\EventSourcing\Testing\AggregateRootScenari
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function getAggregateRootClass()
+    protected function getAggregateRootClass():string
     {
         return Invitation::class;
     }

--- a/examples/event-sourced-domain-with-tests/InvitesTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitesTest.php
@@ -23,7 +23,7 @@ class InvitesTest extends Broadway\EventSourcing\Testing\AggregateRootScenarioTe
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function getAggregateRootClass():string
+    protected function getAggregateRootClass() : string
     {
         return Invitation::class;
     }

--- a/examples/event-sourced-domain-with-tests/InvitesTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitesTest.php
@@ -23,7 +23,7 @@ class InvitesTest extends Broadway\EventSourcing\Testing\AggregateRootScenarioTe
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function getAggregateRootClass() : string
+    protected function getAggregateRootClass(): string
     {
         return Invitation::class;
     }

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
@@ -30,7 +30,7 @@ class JobSeeker extends Broadway\EventSourcing\EventSourcedAggregateRoot
      *
      * @return string
      */
-    public function getAggregateRootId()
+    public function getAggregateRootId(): string
     {
         return $this->jobSeekerId;
     }
@@ -77,7 +77,7 @@ class JobSeeker extends Broadway\EventSourcing\EventSourcedAggregateRoot
         unset($this->jobs[$event->jobId]);
     }
 
-    protected function getChildEntities()
+    protected function getChildEntities(): array
     {
         return $this->jobs;
     }

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Broadway\CommandHandling\CommandHandler;
+
 require_once __DIR__.'/JobSeekers.php';
 
 /**
@@ -24,7 +26,7 @@ class JobSeekersCommandHandlerTest extends Broadway\CommandHandling\Testing\Comm
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();
     }
 
-    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus)
+    protected function createCommandHandler(Broadway\EventStore\EventStore $eventStore, Broadway\EventHandling\EventBus $eventBus): CommandHandler
     {
         $repository = new JobSeekerRepository($eventStore, $eventBus);
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,9 @@
     <testsuite name="Broadway Test Suite">
       <directory>./test/</directory>
     </testsuite>
+    <testsuite name="Broadway Example Test Suite">
+      <directory>./examples/</directory>
+    </testsuite>
   </testsuites>
   <filter>
     <whitelist>

--- a/src/Broadway/EventSourcing/Testing/Scenario.php
+++ b/src/Broadway/EventSourcing/Testing/Scenario.php
@@ -131,6 +131,6 @@ class Scenario
     {
         return array_map(function (DomainMessage $message) {
             return $message->getPayload();
-        }, $this->aggregateRootInstance->getUncommittedEvents());
+        }, iterator_to_array($this->aggregateRootInstance->getUncommittedEvents()));
     }
 }


### PR DESCRIPTION
Fixed missing return types required in strict mode. 

Fixed bug in Scenario->getEvents method: array_map only accepts an array and not an iterator. Using iterator_to_array() now.

Renamed InvitationTest class name to match filename.