### PR TITLE
Introduce distinct entity concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 composer.lock
 .php_cs.cache
+.idea

--- a/src/Broadway/Domain/DistinctEntityEvent.php
+++ b/src/Broadway/Domain/DistinctEntityEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Broadway\Domain;
+
+interface DistinctEntityEvent
+{
+	public function getDistinctEntityId(): string;
+}

--- a/src/Broadway/Domain/DistinctEntityEvent.php
+++ b/src/Broadway/Domain/DistinctEntityEvent.php
@@ -15,5 +15,5 @@ namespace Broadway\Domain;
 
 interface DistinctEntityEvent
 {
-	public function getDistinctEntityId(): string;
+    public function getDistinctEntityId(): string;
 }

--- a/src/Broadway/EventSourcing/DistinctEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/DistinctEventSourcedEntity.php
@@ -15,5 +15,5 @@ namespace Broadway\EventSourcing;
 
 abstract class DistinctEventSourcedEntity extends SimpleEventSourcedEntity
 {
-	abstract public function getEntityId(): string;
+    abstract public function getEntityId(): string;
 }

--- a/src/Broadway/EventSourcing/DistinctEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/DistinctEventSourcedEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Broadway\EventSourcing;
+
+abstract class DistinctEventSourcedEntity extends SimpleEventSourcedEntity
+{
+	abstract public function getEntityId(): string;
+}

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Broadway\EventSourcing;
 
 use Broadway\Domain\AggregateRoot as AggregateRootInterface;
-use Broadway\Domain\DistinctEntityEvent;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
@@ -78,12 +77,12 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
      */
     protected function handle($event)
     {
-	    $A = $event instanceof DistinctEvent;
-	    $B = $this instanceof DistinctEventSourcedEntity;
+        $A = $event instanceof DistinctEvent;
+        $B = $this instanceof DistinctEventSourcedEntity;
 
-	    if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId())  {
-		    return;
-	    }
+        if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId()) {
+            return;
+        }
 
         $method = $this->getApplyMethod($event);
 

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Broadway\EventSourcing;
 
 use Broadway\Domain\AggregateRoot as AggregateRootInterface;
+use Broadway\Domain\DistinctEntityEvent;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
@@ -77,6 +78,13 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
      */
     protected function handle($event)
     {
+	    $A = $event instanceof DistinctEvent;
+	    $B = $this instanceof DistinctEventSourcedEntity;
+
+	    if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId())  {
+		    return;
+	    }
+
         $method = $this->getApplyMethod($event);
 
         if (!method_exists($this, $method)) {

--- a/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
@@ -62,6 +62,13 @@ abstract class SimpleEventSourcedEntity implements EventSourcedEntity
     {
         $method = $this->getApplyMethod($event);
 
+	    $A = $event instanceof DistinctEvent;
+	    $B = $this instanceof DistinctEventSourcedEntity;
+
+	    if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId())  {
+		    return;
+	    }
+
         if (!method_exists($this, $method)) {
             return;
         }

--- a/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
@@ -62,12 +62,12 @@ abstract class SimpleEventSourcedEntity implements EventSourcedEntity
     {
         $method = $this->getApplyMethod($event);
 
-	    $A = $event instanceof DistinctEvent;
-	    $B = $this instanceof DistinctEventSourcedEntity;
+        $A = $event instanceof DistinctEvent;
+        $B = $this instanceof DistinctEventSourcedEntity;
 
-	    if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId())  {
-		    return;
-	    }
+        if ($A && $B && $event->getDistinctEntityId() !== $this->getEntityId()) {
+            return;
+        }
 
         if (!method_exists($this, $method)) {
             return;

--- a/test/Broadway/EventSourcing/DistinctDistinctEventSourcedDistinctEntityTest.php
+++ b/test/Broadway/EventSourcing/DistinctDistinctEventSourcedDistinctEntityTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the broadway/broadway package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Broadway\EventSourcing;
+
+use Broadway\Domain\DistinctEntityEvent;
+use PHPUnit\Framework\TestCase;
+
+class DistinctEventSourcedEntityTest extends TestCase
+{
+	/**
+	 * @test
+	 */
+	public function it_handles_only_entities_with_particular_id()
+	{
+		$aggregate = new TheAggregate();
+		$entityA = new DistinctEntity('A');
+		$entityB = new DistinctEntity('B');
+		$aggregate->addChildEntity($entityA);
+		$aggregate->addChildEntity($entityB);
+
+		$event = new DistinctEvent('A');
+		$aggregate->apply($event);
+
+		$this->assertEquals(1, $entityA->getAppliedEventsNo());
+		$this->assertEquals(0, $entityB->getAppliedEventsNo());
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_handles_nested_entities()
+	{
+		$aggregate = new TheAggregate();
+		$entity1 = new DistinctEntity('1');
+		$entity1A = new DistinctEntity('1A');
+		$entity1->addChildEntity($entity1A);
+		$aggregate->addChildEntity($entity1);
+
+		$event = new DistinctEvent('1A');
+		$aggregate->apply($event);
+
+		$this->assertEquals(0, $entity1->getAppliedEventsNo());
+		$this->assertEquals(1, $entity1A->getAppliedEventsNo());
+	}
+}
+
+class TheAggregate extends EventSourcedAggregateRoot
+{
+	private $children = [];
+
+	protected function getChildEntities(): array
+	{
+		return $this->children;
+	}
+
+	public function addChildEntity($entity)
+	{
+		$this->children[] = $entity;
+	}
+
+	public function getAggregateRootId(): string
+	{
+		return '42';
+	}
+}
+
+class DistinctEntity extends DistinctEventSourcedEntity
+{
+	private $children = [];
+
+	private $id;
+
+	private $appliedEventsNo = 0;
+
+	public function __construct(string $id)
+	{
+		$this->id = $id;
+	}
+
+	public function getEntityId(): string
+	{
+		return (string) $this->id;
+	}
+
+	protected function getChildEntities(): array
+	{
+		return $this->children;
+	}
+
+	public function addChildEntity($entity)
+	{
+		$this->children[] = $entity;
+	}
+
+	protected function applyDistinctEvent($event)
+	{
+		$this->appliedEventsNo++;
+	}
+
+	public function getAppliedEventsNo(): int
+	{
+		return $this->appliedEventsNo;
+	}
+}
+
+class DistinctEvent implements DistinctEntityEvent
+{
+	/**
+	 * @var string
+	 */
+	private $distinctEntityId;
+
+	public function __construct(string $distinctEntityId)
+	{
+		$this->distinctEntityId = $distinctEntityId;
+	}
+
+	public function getDistinctEntityId(): string
+	{
+		return $this->distinctEntityId;
+	}
+}

--- a/test/Broadway/EventSourcing/DistinctDistinctEventSourcedDistinctEntityTest.php
+++ b/test/Broadway/EventSourcing/DistinctDistinctEventSourcedDistinctEntityTest.php
@@ -18,116 +18,116 @@ use PHPUnit\Framework\TestCase;
 
 class DistinctEventSourcedEntityTest extends TestCase
 {
-	/**
-	 * @test
-	 */
-	public function it_handles_only_entities_with_particular_id()
-	{
-		$aggregate = new TheAggregate();
-		$entityA = new DistinctEntity('A');
-		$entityB = new DistinctEntity('B');
-		$aggregate->addChildEntity($entityA);
-		$aggregate->addChildEntity($entityB);
+    /**
+     * @test
+     */
+    public function it_handles_only_entities_with_particular_id()
+    {
+        $aggregate = new TheAggregate();
+        $entityA = new DistinctEntity('A');
+        $entityB = new DistinctEntity('B');
+        $aggregate->addChildEntity($entityA);
+        $aggregate->addChildEntity($entityB);
 
-		$event = new DistinctEvent('A');
-		$aggregate->apply($event);
+        $event = new DistinctEvent('A');
+        $aggregate->apply($event);
 
-		$this->assertEquals(1, $entityA->getAppliedEventsNo());
-		$this->assertEquals(0, $entityB->getAppliedEventsNo());
-	}
+        $this->assertEquals(1, $entityA->getAppliedEventsNo());
+        $this->assertEquals(0, $entityB->getAppliedEventsNo());
+    }
 
-	/**
-	 * @test
-	 */
-	public function it_handles_nested_entities()
-	{
-		$aggregate = new TheAggregate();
-		$entity1 = new DistinctEntity('1');
-		$entity1A = new DistinctEntity('1A');
-		$entity1->addChildEntity($entity1A);
-		$aggregate->addChildEntity($entity1);
+    /**
+     * @test
+     */
+    public function it_handles_nested_entities()
+    {
+        $aggregate = new TheAggregate();
+        $entity1 = new DistinctEntity('1');
+        $entity1A = new DistinctEntity('1A');
+        $entity1->addChildEntity($entity1A);
+        $aggregate->addChildEntity($entity1);
 
-		$event = new DistinctEvent('1A');
-		$aggregate->apply($event);
+        $event = new DistinctEvent('1A');
+        $aggregate->apply($event);
 
-		$this->assertEquals(0, $entity1->getAppliedEventsNo());
-		$this->assertEquals(1, $entity1A->getAppliedEventsNo());
-	}
+        $this->assertEquals(0, $entity1->getAppliedEventsNo());
+        $this->assertEquals(1, $entity1A->getAppliedEventsNo());
+    }
 }
 
 class TheAggregate extends EventSourcedAggregateRoot
 {
-	private $children = [];
+    private $children = [];
 
-	protected function getChildEntities(): array
-	{
-		return $this->children;
-	}
+    protected function getChildEntities(): array
+    {
+        return $this->children;
+    }
 
-	public function addChildEntity($entity)
-	{
-		$this->children[] = $entity;
-	}
+    public function addChildEntity($entity)
+    {
+        $this->children[] = $entity;
+    }
 
-	public function getAggregateRootId(): string
-	{
-		return '42';
-	}
+    public function getAggregateRootId(): string
+    {
+        return '42';
+    }
 }
 
 class DistinctEntity extends DistinctEventSourcedEntity
 {
-	private $children = [];
+    private $children = [];
 
-	private $id;
+    private $id;
 
-	private $appliedEventsNo = 0;
+    private $appliedEventsNo = 0;
 
-	public function __construct(string $id)
-	{
-		$this->id = $id;
-	}
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
 
-	public function getEntityId(): string
-	{
-		return (string) $this->id;
-	}
+    public function getEntityId(): string
+    {
+        return (string) $this->id;
+    }
 
-	protected function getChildEntities(): array
-	{
-		return $this->children;
-	}
+    protected function getChildEntities(): array
+    {
+        return $this->children;
+    }
 
-	public function addChildEntity($entity)
-	{
-		$this->children[] = $entity;
-	}
+    public function addChildEntity($entity)
+    {
+        $this->children[] = $entity;
+    }
 
-	protected function applyDistinctEvent($event)
-	{
-		$this->appliedEventsNo++;
-	}
+    protected function applyDistinctEvent($event)
+    {
+        ++$this->appliedEventsNo;
+    }
 
-	public function getAppliedEventsNo(): int
-	{
-		return $this->appliedEventsNo;
-	}
+    public function getAppliedEventsNo(): int
+    {
+        return $this->appliedEventsNo;
+    }
 }
 
 class DistinctEvent implements DistinctEntityEvent
 {
-	/**
-	 * @var string
-	 */
-	private $distinctEntityId;
+    /**
+     * @var string
+     */
+    private $distinctEntityId;
 
-	public function __construct(string $distinctEntityId)
-	{
-		$this->distinctEntityId = $distinctEntityId;
-	}
+    public function __construct(string $distinctEntityId)
+    {
+        $this->distinctEntityId = $distinctEntityId;
+    }
 
-	public function getDistinctEntityId(): string
-	{
-		return $this->distinctEntityId;
-	}
+    public function getDistinctEntityId(): string
+    {
+        return $this->distinctEntityId;
+    }
 }


### PR DESCRIPTION
Motivation here is quite simple: handle comparing child entity ID as core feature. The problem is aparent in example sourcecode pasted below. With this PR it is no longer necessary to compare the entity ID with event data. See added tests for deeper insight.

```
// code from current JobSeekers.php
    public function applyJobWasDescribedForJobSeekerEvent(JobWasDescribedForJobSeekerEvent $event)
    {
        if ($event->jobId !== $this->jobId) {
            // Make sure that we only apply events that are intended for
            // *this* job instance and no others.
            return;
        }

        $this->title = $event->title;
        $this->description = $event->description;
    }
```

