### PR TITLE
Simple command bus - Manage Throwable exceptions

### DIFF
--- a/src/Broadway/CommandHandling/SimpleCommandBus.php
+++ b/src/Broadway/CommandHandling/SimpleCommandBus.php
@@ -51,6 +51,9 @@ final class SimpleCommandBus implements CommandBus
             } catch (\Exception $e) {
                 $this->isDispatching = false;
                 throw $e;
+            } catch (\Throwable $e) {
+                $this->isDispatching = false;
+                throw $e;
             }
         }
     }

--- a/src/Broadway/CommandHandling/SimpleCommandBus.php
+++ b/src/Broadway/CommandHandling/SimpleCommandBus.php
@@ -46,14 +46,8 @@ final class SimpleCommandBus implements CommandBus
                         $handler->handle($command);
                     }
                 }
-
+            } finally {
                 $this->isDispatching = false;
-            } catch (\Exception $e) {
-                $this->isDispatching = false;
-                throw $e;
-            } catch (\Throwable $e) {
-                $this->isDispatching = false;
-                throw $e;
             }
         }
     }

--- a/test/Broadway/CommandHandling/SimpleCommandBusTest.php
+++ b/test/Broadway/CommandHandling/SimpleCommandBusTest.php
@@ -103,46 +103,6 @@ class SimpleCommandBusTest extends TestCase
         $this->commandBus->dispatch($command2);
     }
 
-    /**
-     * @test
-     */
-    public function it_should_still_handle_commands_after_throwable()
-    {
-        $command1 = ['foo' => 'bar'];
-        $command2 = ['foo' => 'bas'];
-
-        $commandHandler = $this->createMock(CommandHandler::class);
-        $simpleHandler = $this->createMock(CommandHandler::class);
-
-        $commandHandler
-            ->expects($this->at(0))
-            ->method('handle')
-            ->with($command1)
-            ->will($this->throwException(new \Error('I failed.')));
-
-        $commandHandler
-            ->expects($this->at(0))
-            ->method('handle')
-            ->with($command2);
-
-        $simpleHandler
-            ->expects($this->once())
-            ->method('handle')
-            ->with($command2);
-
-        $this->commandBus->subscribe($commandHandler);
-        $this->commandBus->subscribe($simpleHandler);
-
-        try {
-            $this->commandBus->dispatch($command1);
-        } catch (\Throwable $e) {
-            $this->assertEquals('I failed.', $e->getMessage());
-        }
-
-        $this->commandBus->dispatch($command2);
-    }
-
-
     private function createCommandHandlerMock(array $expectedCommand): \PHPUnit_Framework_MockObject_MockObject
     {
         $mock = $this->createMock(CommandHandler::class);


### PR DESCRIPTION
# Goal:
This PR aims to allow simple command bus to manage all kind of exceptions, using "finally" as you are already using for the event bus implementation, in order to flag it as isDispatching false either if it went ok or ko (exception thrown)
Related issue: https://github.com/broadway/broadway/issues/357