### PR TITLE
Change the order of event applying in aggregate from root-to-leaf to leaf-to-root

### DIFF
--- a/examples/event-sourced-child-entity/Parts.php
+++ b/examples/event-sourced-child-entity/Parts.php
@@ -66,11 +66,7 @@ class Part extends Broadway\EventSourcing\EventSourcedAggregateRoot
 
     protected function getChildEntities(): array
     {
-        // Since the aggregate root always handles the events first we can rely
-        // on $this->manufacturer being set by the time the child entities are
-        // requested *provided* PartWasManufacturedEvent is the first event in
-        // the event stream.
-        return [$this->manufacturer];
+        return ($this->manufacturer !== null )  ? [$this->manufacturer] : []; 
     }
 }
 

--- a/examples/event-sourced-child-entity/Parts.php
+++ b/examples/event-sourced-child-entity/Parts.php
@@ -58,6 +58,7 @@ class Part extends Broadway\EventSourcing\EventSourcedAggregateRoot
         // the child entity is instantiated and returned by getChildEntities()
         // it can emit and apply events itself.
         $this->manufacturer = new Manufacturer(
+            $this,
             $event->partId,
             $event->manufacturerId,
             $event->manufacturerName
@@ -76,8 +77,9 @@ class Manufacturer extends Broadway\EventSourcing\SimpleEventSourcedEntity
     private $manufacturerId;
     private $manufacturerName;
 
-    public function __construct($partId, $manufacturerId, $manufacturerName)
+    public function __construct(Broadway\EventSourcing\EventSourcedAggregateRoot $aggregateRoot, $partId, $manufacturerId, $manufacturerName)
     {
+        parent::__construct($aggregateRoot);
         $this->partId = $partId;
         $this->manufacturerId = $manufacturerId;
         $this->manufacturerName = $manufacturerName;

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
@@ -73,6 +73,7 @@ class JobSeeker extends Broadway\EventSourcing\EventSourcedAggregateRoot
     public function applyJobWasAddedToJobSeekerEvent(JobWasAddedToJobSeekerEvent $event)
     {
         $this->jobs[$event->jobId] = new Job(
+            $this,
             $event->jobSeekerId,
             $event->jobId,
             $event->title,
@@ -99,8 +100,9 @@ class Job extends Broadway\EventSourcing\SimpleEventSourcedEntity
     private $title;
     private $description;
 
-    public function __construct($jobSeekerId, $jobId, $title, $description)
+    public function __construct(Broadway\EventSourcing\EventSourcedAggregateRoot $aggregateRoot, $jobSeekerId, $jobId, $title, $description)
     {
+        parent::__construct($aggregateRoot);
         $this->jobSeekerId = $jobSeekerId;
         $this->jobId = $jobId;
         $this->title = $title;

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -92,7 +92,6 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
     protected function handleRecursively($event): void
     {
         foreach ($this->getChildEntities() as $entity) {
-            $entity->registerAggregateRoot($this);
             $entity->handleRecursively($event);
         }
 

--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -91,12 +91,12 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
      */
     protected function handleRecursively($event): void
     {
-        $this->handle($event);
-
         foreach ($this->getChildEntities() as $entity) {
             $entity->registerAggregateRoot($this);
             $entity->handleRecursively($event);
         }
+
+        $this->handle($event);
     }
 
     /**

--- a/src/Broadway/EventSourcing/EventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/EventSourcedEntity.php
@@ -24,11 +24,4 @@ interface EventSourcedEntity
      * @param mixed $event
      */
     public function handleRecursively($event): void;
-
-    /**
-     * Registers aggregateRoot as this EventSourcedEntity's aggregate root.
-     *
-     * @throws AggregateRootAlreadyRegisteredException
-     */
-    public function registerAggregateRoot(EventSourcedAggregateRoot $aggregateRoot): void;
 }

--- a/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
@@ -23,29 +23,21 @@ abstract class SimpleEventSourcedEntity implements EventSourcedEntity
      */
     private $aggregateRoot;
 
+    public function __construct(EventSourcedAggregateRoot $aggregateRoot)
+    {
+        $this->aggregateRoot = $aggregateRoot;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function handleRecursively($event): void
     {
         foreach ($this->getChildEntities() as $entity) {
-            $entity->registerAggregateRoot($this->aggregateRoot);
             $entity->handleRecursively($event);
         }
 
         $this->handle($event);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function registerAggregateRoot(EventSourcedAggregateRoot $aggregateRoot): void
-    {
-        if (null !== $this->aggregateRoot && $this->aggregateRoot !== $aggregateRoot) {
-            throw new AggregateRootAlreadyRegisteredException();
-        }
-
-        $this->aggregateRoot = $aggregateRoot;
     }
 
     /**

--- a/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
+++ b/src/Broadway/EventSourcing/SimpleEventSourcedEntity.php
@@ -28,12 +28,12 @@ abstract class SimpleEventSourcedEntity implements EventSourcedEntity
      */
     public function handleRecursively($event): void
     {
-        $this->handle($event);
-
         foreach ($this->getChildEntities() as $entity) {
             $entity->registerAggregateRoot($this->aggregateRoot);
             $entity->handleRecursively($event);
         }
+
+        $this->handle($event);
     }
 
     /**

--- a/test/Broadway/EventSourcing/SimpleEventSourcedEntityTest.php
+++ b/test/Broadway/EventSourcing/SimpleEventSourcedEntityTest.php
@@ -23,12 +23,13 @@ class SimpleEventSourcedEntityTest extends TestCase
     public function it_handles_events_recursively()
     {
         $aggregateRoot = new Aggregate();
-        $child = new Entity();
+        $child = new Entity($aggregateRoot);
 
         $aggregateRoot->addChildEntity($child);
 
         $mock = $this->getMockBuilder('Broadway\EventSourcing\Entity')
             ->setMethods(['handleRecursively'])
+            ->setConstructorArgs([$aggregateRoot])
             ->getMock();
 
         $mock->expects($this->once())
@@ -51,8 +52,8 @@ class SimpleEventSourcedEntityTest extends TestCase
         $aggregateRoot->expects($this->once())
             ->method('apply');
 
-        $child = new Entity();
-        $grandChild = new Entity();
+        $child = new Entity($aggregateRoot);
+        $grandChild = new Entity($aggregateRoot);
 
         $aggregateRoot->addChildEntity($child);
 
@@ -60,25 +61,6 @@ class SimpleEventSourcedEntityTest extends TestCase
         $aggregateRoot->doHandleRecursively();  // Initialize tree structure
 
         $grandChild->doApply();
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_only_have_one_root()
-    {
-        $root1 = new Aggregate();
-        $root2 = new Aggregate();
-
-        $entity = new Entity();
-
-        $root1->addChildEntity($entity);
-        $root2->addChildEntity($entity);
-
-        $this->expectException(AggregateRootAlreadyRegisteredException::class);
-
-        $root1->doHandleRecursively();
-        $root2->doHandleRecursively();
     }
 }
 


### PR DESCRIPTION
This PR aims to reverse the order of applying the event over an aggregate - instead of applying it top-down, event should be applied from the leafs and work towards the root.

The reason behind that is that when applying an event on an entity within the aggregate, we cannot rely on our child entities ( because they didn't apply the event yet ).

Let me introduce a minimalistic example - Imagine a classic shopping basket with a twist - if basket's contents exceed 100 USD, we mark a basket as important ( Management cares about big baskets! ) and we allow the basket holder to do something more. We also allow to mark a basket as important explicitly ( because why not and it's just an example :) ). And we also are able to apply a discount to a product within a basket. Let's write it out ( only relevant parts are here ):

`

class Product extends SimpleEventSourcedEntity {

      private $price;

      public function applyDiscountGranted(DiscountGranted $event) {
              $this->price = (100 - $event->discount()) / 100 * $this->price;
      }
}

class Basket extends EventSourcedAggregateRoot {
    
     private $products;

     private $important;
     
    public function applyDiscountGranted(DiscountGranted $event){
     {
           if($this->products->sum() >= 100) {
                   $this->important = true;
           }
     }

     public function becomeAnImportantBasket()
     {
          //No domain-specific rules, anyone can explicitly ask to become an important basket. :)
          $this->apply(new BecomeImportant());
     }

    public function applyBecomeImportant(BecomeImportant $event) {
        $this->important = true;
    }

     public function doSomethingSpecial()
     {
            if($this->important) {
                 //Do something special with our important basket
            }         
     }
    
}
`

Now, the problem is that this aggregate would malfunction under Broadway, because when doing our comparison check within Basket::applyDiscountGranted() function we'll have a wrong sum of products' prices, and this is because Basket::applyDiscountGranted() is called before Product::applyDiscountGranted().

Of course, one could argue that we shouldn't modify state based on child entities' state within event applying routines, so let's try that for a moment:

`

class Product extends SimpleEventSourcedEntity {

      private $price;

      public function applyDiscountGranted(DiscountGranted $event) {
              $this->price = (100 - $event->discount()) / 100 * $this->price;
      }
}

class Basket extends EventSourcedAggregateRoot {
    
     private $products;

     private $important;

     public function becomeAnImportantBasket()
     {
          //No domain-specific rules, anyone can explicitly ask to become an important basket. :)
          $this->apply(new BecomeImportant());
     }

    public function applyBecomeImportant(BecomeImportant $event) {
        $this->important = true;
    }

     public function doSomethingSpecial()
     {
            if($this->isImportant()) {
                 //Do something special with our important basket
            }         
     }

     private function isImportant()
     {
           return ($this->products->sum() >= 100 || $this->important);
     }
    
}
`

However, this approach has a subtle problem. Imagine that business rules change ( they always change! ) and the "important basket threshold" changes to 200 USD. However, when we make the change, the problem becomes evident - playing back events from the past will break, because they will now all adhere to the new threshold, and surely events that happened in the past ought not to change state based on current rules. This is a classic events' versioning problem, one that can be easily solved by versioning events, but to do so, we need to version it within the applying function, but we cannot, because we took the logic out of it.

Another approach one could take is to save this information within the event, but this obviously clutters the event with the information that isn't relevant to it, and hence I discard it.

If you see any fallacy in my logic behind this PR or think I didn't understand something well, make sure to point it out, as this PR is also meant to be a discussion for/against rather than mere code change.
