### PR TITLE
Add replay events feature

### DIFF
--- a/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
@@ -84,6 +84,14 @@ final class ConcurrencyConflictResolvingEventStore implements EventStore
         return $this->eventStore->loadFromPlayhead($id, $playhead);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function loadFromPlayheadToPlayhead($id, int $fromPlayhead, int $toPlayhead): DomainEventStream
+    {
+        return $this->eventStore->loadFromPlayheadToPlayhead($id, $fromPlayhead, $toPlayhead);
+    }
+
     private function getCurrentPlayhead(DomainEventStream $committedEvents): int
     {
         $events = iterator_to_array($committedEvents);

--- a/src/Broadway/EventStore/EventStore.php
+++ b/src/Broadway/EventStore/EventStore.php
@@ -28,13 +28,16 @@ interface EventStore
 
     /**
      * @param mixed $id
-     * @param int   $playhead
      */
     public function loadFromPlayhead($id, int $playhead): DomainEventStream;
 
     /**
-     * @param mixed             $id
-     * @param DomainEventStream $eventStream
+     * @param mixed $id
+     */
+    public function loadFromPlayheadToPlayhead($id, int $fromPlayhead, int $toPlayhead): DomainEventStream;
+
+    /**
+     * @param mixed $id
      *
      * @throws DuplicatePlayheadException
      */

--- a/src/Broadway/EventStore/Management/EventStoreManagement.php
+++ b/src/Broadway/EventStore/Management/EventStoreManagement.php
@@ -18,4 +18,9 @@ use Broadway\EventStore\EventVisitor;
 interface EventStoreManagement
 {
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor): void;
+
+    /**
+     * @param $id
+     */
+    public function replay($id, int $fromPlayhead, ?int $toPlayhead = null): void;
 }

--- a/src/Broadway/EventStore/TraceableEventStore.php
+++ b/src/Broadway/EventStore/TraceableEventStore.php
@@ -76,6 +76,14 @@ final class TraceableEventStore implements EventStore
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadFromPlayheadToPlayhead($id, int $fromPlayhead, int $toPlayhead): DomainEventStream
+    {
+        return $this->eventStore->loadFromPlayheadToPlayhead($id, $fromPlayhead, $toPlayhead);
+    }
+
+    /**
      * Start tracing.
      */
     public function trace(): void

--- a/src/Broadway/Repository/Repository.php
+++ b/src/Broadway/Repository/Repository.php
@@ -31,8 +31,6 @@ interface Repository
      * @param mixed $id
      *
      * @throws AggregateNotFoundException
-     *
-     * @return AggregateRoot
      */
     public function load($id): AggregateRoot;
 }


### PR DESCRIPTION
In some use cases you need to replay certain events.

Let's say a bug introduced an error in aggregateRootID `foo`, version `32` and `33`.
As events are immutable I want to be able to add manually an event, let's say version `32.1` and replay the events to recompose the history.

This PR introduce the replay feature, but doesn't change the playhead attribute to float.