### PR TITLE
Improvements to serializer code

### DIFF
--- a/src/Broadway/Serializer/ReflectionSerializer.php
+++ b/src/Broadway/Serializer/ReflectionSerializer.php
@@ -27,6 +27,10 @@ class ReflectionSerializer implements Serializer
      */
     public function serialize($object): array
     {
+        if (!is_object($object) || $object instanceof \stdClass) {
+            throw new \InvalidArgumentException('Given argument is not serializable.');
+        }
+
         return $this->serializeObjectRecursively($object);
     }
 

--- a/src/Broadway/Serializer/SimpleInterfaceSerializer.php
+++ b/src/Broadway/Serializer/SimpleInterfaceSerializer.php
@@ -26,10 +26,16 @@ final class SimpleInterfaceSerializer implements Serializer
     public function serialize($object): array
     {
         if (!$object instanceof Serializable) {
-            throw new SerializationException(sprintf(
-                'Object \'%s\' does not implement Broadway\Serializer\Serializable',
-                get_class($object)
-            ));
+            if (is_object($object)) {
+                throw new SerializationException(sprintf(
+                    'Object \'%s\' does not implement Broadway\Serializer\Serializable',
+                    get_class($object)
+                ));
+            } else {
+                throw new SerializationException(
+                    'Given argument is not an object.'
+                );
+            }
         }
 
         return [

--- a/test/Broadway/Serializer/ReflectionSerializerTest.php
+++ b/test/Broadway/Serializer/ReflectionSerializerTest.php
@@ -38,7 +38,7 @@ class ReflectionSerializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Key \'class\' should be set');
 
-        $this->serializer->deserialize([]);
+        $this->serializer->deserialize(['payload' => []]);
     }
 
     /**

--- a/test/Broadway/Serializer/ReflectionSerializerTest.php
+++ b/test/Broadway/Serializer/ReflectionSerializerTest.php
@@ -162,6 +162,7 @@ class ReflectionSerializerTest extends TestCase
             'string' => ['impossible'],
             'array' => [[]],
             'object' => [(object)[]],
+            'bad array' => [['class' => 'foo', 'payload' => 'bar']],
         ];
     }
 }

--- a/test/Broadway/Serializer/ReflectionSerializerTest.php
+++ b/test/Broadway/Serializer/ReflectionSerializerTest.php
@@ -142,6 +142,17 @@ class ReflectionSerializerTest extends TestCase
         $this->assertEquals($object, $deserialized);
     }
 
+    /**
+     * @test
+     * @dataProvider serializable_test_data
+     */
+    public function it_fails_to_serialize($data)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->serializer->serialize($data);
+    }
+
     public function serializable_test_data()
     {
         return [

--- a/test/Broadway/Serializer/ReflectionSerializerTest.php
+++ b/test/Broadway/Serializer/ReflectionSerializerTest.php
@@ -125,6 +125,34 @@ class ReflectionSerializerTest extends TestCase
 
         $this->assertEquals($object, $this->serializer->deserialize($data));
     }
+
+    /**
+     * @test
+     * @dataProvider serializable_test_data
+     */
+    public function it_serializes($data)
+    {
+        $object = new TestReflectableObject([], $data);
+
+        $serialized = $this->serializer->serialize($object);
+
+        $deserialized = $this->serializer->deserialize($serialized);
+
+        $this->assertInstanceOf(TestReflectableObject::class, $deserialized);
+        $this->assertEquals($object, $deserialized);
+    }
+
+    public function serializable_test_data()
+    {
+        return [
+            'null' => [null],
+            'integer' => [0],
+            'float' => [3.14],
+            'string' => ['impossible'],
+            'array' => [[]],
+            'object' => [(object)[]],
+        ];
+    }
 }
 
 class TestReflectableObject

--- a/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
+++ b/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
@@ -141,6 +141,7 @@ class SimpleInterfaceSerializerTest extends TestCase
             'string' => ['impossible'],
             'array' => [[]],
             'object' => [(object)[]],
+            'bad array' => [['class' => 'foo', 'payload' => 'bar']],
         ];
     }
 }

--- a/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
+++ b/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
@@ -121,6 +121,17 @@ class SimpleInterfaceSerializerTest extends TestCase
         $this->assertEquals($object, $deserialized);
     }
 
+    /**
+     * @test
+     * @dataProvider serializable_test_data
+     */
+    public function it_fails_to_serialize($data)
+    {
+        $this->expectException(SerializationException::class);
+
+        $this->serializer->serialize($data);
+    }
+
     public function serializable_test_data()
     {
         return [

--- a/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
+++ b/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
@@ -53,7 +53,7 @@ class SimpleInterfaceSerializerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Key \'class\' should be set');
 
-        $this->serializer->deserialize([]);
+        $this->serializer->deserialize(['payload' => []]);
     }
 
     /**

--- a/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
+++ b/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
@@ -104,6 +104,34 @@ class SimpleInterfaceSerializerTest extends TestCase
 
         $this->assertEquals($object, $deserialized);
     }
+
+    /**
+     * @test
+     * @dataProvider serializable_test_data
+     */
+    public function it_serializes($data)
+    {
+        $object = new TestSerializable($data);
+
+        $serialized = $this->serializer->serialize($object);
+
+        $deserialized = $this->serializer->deserialize($serialized);
+
+        $this->assertInstanceOf(TestSerializable::class, $deserialized);
+        $this->assertEquals($object, $deserialized);
+    }
+
+    public function serializable_test_data()
+    {
+        return [
+            'null' => [null],
+            'integer' => [0],
+            'float' => [3.14],
+            'string' => ['impossible'],
+            'array' => [[]],
+            'object' => [(object)[]],
+        ];
+    }
 }
 
 class TestSerializable implements Serializable


### PR DESCRIPTION
I stumbled across a few glitches in the serializers that caused a bit of confusion while trying to integrate Broadway into one of our projects. For some of the bugs, I created according commits that address them, both concerning the tests and the actual code. However, there's one problem left, meaning that this pull request should not yet be merged.

The problem is illustrated by commit 9991588. There, a serialized object contains a payload that resembles the serialized form of an object, which the serializer using reflection fails to restore correctly. I could imagine a fix for that, but that would imply a change to the format which is *not* backward compatible, so I didn't even start implementing it.