### PR TITLE
Make EventSourcedAggregateRoot playhead protected

### DIFF
--- a/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
+++ b/src/Broadway/EventSourcing/EventSourcedAggregateRoot.php
@@ -27,7 +27,7 @@ abstract class EventSourcedAggregateRoot implements AggregateRootInterface
      * @var array
      */
     private $uncommittedEvents = [];
-    private $playhead = -1; // 0-based playhead allows events[0] to contain playhead 0
+    protected $playhead = -1; // 0-based playhead allows events[0] to contain playhead 0
 
     /**
      * Applies an event. The event is added to the AggregateRoot's list of uncommitted events.


### PR DESCRIPTION
Maybe I'm doing it wrong, but to obtain an aggregate root from a snapshot I use the following:
```php
    use use Broadway\Serializer\Serializer;
    // ...
    private function deserializeSnapshot($row): Snapshot
    {
        return new Snapshot(
            $this->payloadSerializer->deserialize(json_decode($row['payload'], true))
        );
    }
```
but the catch is that the aggregate root playhead is never set and stays equal to -1, which makes all events to be replayed even when using a snapshot. As far as I see it, the aggregate root must have its playhead properly set and an easy way is to have the playhead set on deserialization:
```php
    private function deserializeSnapshot($row): Snapshot
    {
        $payload = json_decode($row['payload'], true);
        $payload['playhead'] = $row['playhead'];
        return new Snapshot(
            $this->payloadSerializer->deserialize($payload)
        );
    }
```
But for this to happen, EventSourcedAggregateRoot playhead must be protected and not private.    
Or should I use the snapshot differently?