### PR TITLE
php 7.4 and PHPUnit 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 matrix:
     include:
-        - php: 7.1
         - php: 7.2
         - php: 7.3
         - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - php: 7.1
         - php: 7.2
         - php: 7.3
+        - php: 7.4
     fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "beberlei/assert": "~3.0",
         "broadway/uuid-generator": "~0.4.0",
-        "php": ">=7.1"
+        "php": ">=7.2"
     },
     "authors": [
       {
@@ -36,7 +36,7 @@
     ],
     "require-dev": {
         "monolog/monolog": "~1.8",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^8.0",
         "ramsey/uuid": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.1",
         "malukenho/docheader": "^0.1.7"

--- a/examples/event-sourced-child-entity/Parts.php
+++ b/examples/event-sourced-child-entity/Parts.php
@@ -36,8 +36,6 @@ class Part extends Broadway\EventSourcing\EventSourcedAggregateRoot
 
     /**
      * Every aggregate root will expose its id.
-     *
-     * @return string
      */
     public function getAggregateRootId(): string
     {

--- a/examples/event-sourced-child-entity/PartsTest.php
+++ b/examples/event-sourced-child-entity/PartsTest.php
@@ -29,7 +29,7 @@ class PartsCommandHandlerTest extends Broadway\CommandHandling\Testing\CommandHa
 {
     private $generator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();

--- a/examples/event-sourced-domain-with-tests/InvitationCommandHandlerTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitationCommandHandlerTest.php
@@ -29,7 +29,7 @@ class InvitationCommandHandlerTest extends Broadway\CommandHandling\Testing\Comm
 {
     private $generator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();

--- a/examples/event-sourced-domain-with-tests/InvitesTest.php
+++ b/examples/event-sourced-domain-with-tests/InvitesTest.php
@@ -26,7 +26,7 @@ class InvitesTest extends Broadway\EventSourcing\Testing\AggregateRootScenarioTe
 {
     private $generator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekers.php
@@ -36,8 +36,6 @@ class JobSeeker extends Broadway\EventSourcing\EventSourcedAggregateRoot
 
     /**
      * Every aggregate root will expose its id.
-     *
-     * @return string
      */
     public function getAggregateRootId(): string
     {

--- a/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
+++ b/examples/event-sourced-multiple-dyanmic-child-entities/JobSeekersTest.php
@@ -29,7 +29,7 @@ class JobSeekersCommandHandlerTest extends Broadway\CommandHandling\Testing\Comm
 {
     private $generator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->generator = new Broadway\UuidGenerator\Rfc4122\Version4Generator();

--- a/examples/querying-the-event-store/query-memory-events-with-criteria.php
+++ b/examples/querying-the-event-store/query-memory-events-with-criteria.php
@@ -12,9 +12,9 @@
 declare(strict_types=1);
 
 use Broadway\Domain\DomainEventStream;
+use Broadway\EventStore\CallableEventVisitor;
 use Broadway\EventStore\InMemoryEventStore;
 use Broadway\EventStore\Management\Criteria;
-use Broadway\EventStore\CallableEventVisitor;
 
 require __DIR__.'/../event-sourced-domain-with-tests/Invites.php';
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
   <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
   <testsuites>

--- a/src/Broadway/Auditing/CommandSerializer.php
+++ b/src/Broadway/Auditing/CommandSerializer.php
@@ -22,8 +22,6 @@ interface CommandSerializer
      * Serializes the command.
      *
      * @param mixed $command
-     *
-     * @return array
      */
     public function serialize($command): array;
 }

--- a/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
+++ b/src/Broadway/CommandHandling/Testing/CommandHandlerScenarioTestCase.php
@@ -31,14 +31,11 @@ abstract class CommandHandlerScenarioTestCase extends TestCase
      */
     protected $scenario;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->scenario = $this->createScenario();
     }
 
-    /**
-     * @return Scenario
-     */
     protected function createScenario(): Scenario
     {
         $eventStore = new TraceableEventStore(new InMemoryEventStore());
@@ -50,11 +47,6 @@ abstract class CommandHandlerScenarioTestCase extends TestCase
 
     /**
      * Create a command handler for the given scenario test case.
-     *
-     * @param EventStore $eventStore
-     * @param EventBus   $eventBus
-     *
-     * @return CommandHandler
      */
     abstract protected function createCommandHandler(EventStore $eventStore, EventBus $eventBus): CommandHandler;
 }

--- a/src/Broadway/Domain/AggregateRoot.php
+++ b/src/Broadway/Domain/AggregateRoot.php
@@ -18,13 +18,7 @@ namespace Broadway\Domain;
  */
 interface AggregateRoot
 {
-    /**
-     * @return DomainEventStream
-     */
     public function getUncommittedEvents(): DomainEventStream;
 
-    /**
-     * @return string
-     */
     public function getAggregateRootId(): string;
 }

--- a/src/Broadway/Domain/DomainEventStream.php
+++ b/src/Broadway/Domain/DomainEventStream.php
@@ -31,9 +31,6 @@ final class DomainEventStream implements IteratorAggregate
         $this->events = $events;
     }
 
-    /**
-     * @return ArrayIterator
-     */
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->events);

--- a/src/Broadway/Domain/DomainMessage.php
+++ b/src/Broadway/Domain/DomainMessage.php
@@ -44,11 +44,8 @@ final class DomainMessage
     private $recordedOn;
 
     /**
-     * @param mixed    $id
-     * @param int      $playhead
-     * @param Metadata $metadata
-     * @param mixed    $payload
-     * @param DateTime $recordedOn
+     * @param mixed $id
+     * @param mixed $payload
      */
     public function __construct($id, int $playhead, Metadata $metadata, $payload, DateTime $recordedOn)
     {
@@ -59,25 +56,16 @@ final class DomainMessage
         $this->recordedOn = $recordedOn;
     }
 
-    /**
-     * @return string
-     */
     public function getId(): string
     {
         return $this->id;
     }
 
-    /**
-     * @return int
-     */
     public function getPlayhead(): int
     {
         return $this->playhead;
     }
 
-    /**
-     * @return Metadata
-     */
     public function getMetadata(): Metadata
     {
         return $this->metadata;
@@ -91,27 +79,19 @@ final class DomainMessage
         return $this->payload;
     }
 
-    /**
-     * @return DateTime
-     */
     public function getRecordedOn(): DateTime
     {
         return $this->recordedOn;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return strtr(get_class($this->payload), '\\', '.');
     }
 
     /**
-     * @param mixed    $id
-     * @param int      $playhead
-     * @param Metadata $metadata
-     * @param mixed    $payload
+     * @param mixed $id
+     * @param mixed $payload
      */
     public static function recordNow($id, int $playhead, Metadata $metadata, $payload): self
     {

--- a/src/Broadway/Domain/Metadata.php
+++ b/src/Broadway/Domain/Metadata.php
@@ -22,9 +22,6 @@ final class Metadata implements Serializable
 {
     private $values = [];
 
-    /**
-     * @param array $values
-     */
     public function __construct(array $values = [])
     {
         $this->values = $values;
@@ -78,8 +75,6 @@ final class Metadata implements Serializable
     }
 
     /**
-     * @param array $data
-     *
      * @return Metadata
      */
     public static function deserialize(array $data): self

--- a/src/Broadway/EventSourcing/AggregateFactory/AggregateFactory.php
+++ b/src/Broadway/EventSourcing/AggregateFactory/AggregateFactory.php
@@ -19,10 +19,7 @@ use Broadway\EventSourcing\EventSourcedAggregateRoot;
 interface AggregateFactory
 {
     /**
-     * @param string            $aggregateClass    the FQCN of the Aggregate to create
-     * @param DomainEventStream $domainEventStream
-     *
-     * @return EventSourcedAggregateRoot
+     * @param string $aggregateClass the FQCN of the Aggregate to create
      */
     public function create(string $aggregateClass, DomainEventStream $domainEventStream): EventSourcedAggregateRoot;
 }

--- a/src/Broadway/EventSourcing/EventSourcingRepository.php
+++ b/src/Broadway/EventSourcing/EventSourcingRepository.php
@@ -35,10 +35,6 @@ class EventSourcingRepository implements Repository
     private $aggregateFactory;
 
     /**
-     * @param EventStore             $eventStore
-     * @param EventBus               $eventBus
-     * @param string                 $aggregateClass
-     * @param AggregateFactory       $aggregateFactory
      * @param EventStreamDecorator[] $eventStreamDecorators
      */
     public function __construct(

--- a/src/Broadway/EventSourcing/EventStreamDecorator.php
+++ b/src/Broadway/EventSourcing/EventStreamDecorator.php
@@ -24,12 +24,5 @@ use Broadway\Domain\DomainEventStream;
  */
 interface EventStreamDecorator
 {
-    /**
-     * @param string            $aggregateType
-     * @param string            $aggregateIdentifier
-     * @param DomainEventStream $eventStream
-     *
-     * @return DomainEventStream
-     */
     public function decorateForWrite(string $aggregateType, string $aggregateIdentifier, DomainEventStream $eventStream): DomainEventStream;
 }

--- a/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnricher.php
+++ b/src/Broadway/EventSourcing/MetadataEnrichment/MetadataEnricher.php
@@ -20,8 +20,5 @@ use Broadway\Domain\Metadata;
  */
 interface MetadataEnricher
 {
-    /**
-     * @return Metadata
-     */
     public function enrich(Metadata $metadata): Metadata;
 }

--- a/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
+++ b/src/Broadway/EventSourcing/Testing/AggregateRootScenarioTestCase.php
@@ -27,14 +27,11 @@ abstract class AggregateRootScenarioTestCase extends TestCase
      */
     protected $scenario;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->scenario = $this->createScenario();
     }
 
-    /**
-     * @return Scenario
-     */
     protected function createScenario(): Scenario
     {
         $aggregateRootClass = $this->getAggregateRootClass();

--- a/src/Broadway/EventStore/EventStore.php
+++ b/src/Broadway/EventStore/EventStore.php
@@ -28,13 +28,11 @@ interface EventStore
 
     /**
      * @param mixed $id
-     * @param int   $playhead
      */
     public function loadFromPlayhead($id, int $playhead): DomainEventStream;
 
     /**
-     * @param mixed             $id
-     * @param DomainEventStream $eventStream
+     * @param mixed $id
      *
      * @throws DuplicatePlayheadException
      */

--- a/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
+++ b/src/Broadway/EventStore/Exception/DuplicatePlayheadException.php
@@ -25,8 +25,7 @@ final class DuplicatePlayheadException extends EventStoreException
     private $eventStream;
 
     /**
-     * @param DomainEventStream $eventStream
-     * @param Exception         $previous
+     * @param Exception $previous
      */
     public function __construct(DomainEventStream $eventStream, $previous = null)
     {
@@ -35,9 +34,6 @@ final class DuplicatePlayheadException extends EventStoreException
         $this->eventStream = $eventStream;
     }
 
-    /**
-     * @return DomainEventStream
-     */
     public function getEventStream(): DomainEventStream
     {
         return $this->eventStream;

--- a/src/Broadway/EventStore/InMemoryEventStore.php
+++ b/src/Broadway/EventStore/InMemoryEventStore.php
@@ -87,8 +87,7 @@ final class InMemoryEventStore implements EventStore, EventStoreManagement
     }
 
     /**
-     * @param DomainMessage[]   $events
-     * @param DomainEventStream $eventsToAppend
+     * @param DomainMessage[] $events
      */
     private function assertStream(array $events, DomainEventStream $eventsToAppend): void
     {

--- a/src/Broadway/EventStore/Management/Criteria.php
+++ b/src/Broadway/EventStore/Management/Criteria.php
@@ -100,17 +100,11 @@ final class Criteria
 
     /**
      * Determine if a domain message is matched by this criteria.
-     *
-     * @param DomainMessage $domainMessage
-     *
-     * @return bool
      */
     public function isMatchedBy(DomainMessage $domainMessage): bool
     {
         if ($this->aggregateRootTypes) {
-            throw new CriteriaNotSupportedException(
-                'Cannot match criteria based on aggregate root types.'
-            );
+            throw new CriteriaNotSupportedException('Cannot match criteria based on aggregate root types.');
         }
 
         if ($this->aggregateRootIds && !in_array($domainMessage->getId(), $this->aggregateRootIds)) {

--- a/src/Broadway/EventStore/Management/Testing/EventStoreManagementTest.php
+++ b/src/Broadway/EventStore/Management/Testing/EventStoreManagementTest.php
@@ -36,7 +36,7 @@ abstract class EventStoreManagementTest extends TestCase
      */
     protected $now;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->now = DateTime::now();
         $this->eventStore = $this->createEventStore();

--- a/src/Broadway/EventStore/Testing/EventStoreTest.php
+++ b/src/Broadway/EventStore/Testing/EventStoreTest.php
@@ -113,7 +113,12 @@ abstract class EventStoreTest extends TestCase
             'Yolntbyaac' //You only live nine times because you are a cat
         );
 
-        $this->expectException(Error::class);
+        if (PHP_VERSION_ID > 70400) {
+            $this->expectException(\Throwable::class);
+        } else {
+            $this->expectException(Error::class);
+        }
+
         $this->expectExceptionMessage(sprintf(
             'Object of class %s could not be converted to string',
             IdentityThatCannotBeConvertedToAString::class

--- a/src/Broadway/ReadModel/Identifiable.php
+++ b/src/Broadway/ReadModel/Identifiable.php
@@ -18,8 +18,5 @@ namespace Broadway\ReadModel;
  */
 interface Identifiable
 {
-    /**
-     * @return string
-     */
     public function getId(): string;
 }

--- a/src/Broadway/ReadModel/Repository.php
+++ b/src/Broadway/ReadModel/Repository.php
@@ -26,8 +26,6 @@ interface Repository
     public function find($id): ?Identifiable;
 
     /**
-     * @param array $fields
-     *
      * @return Identifiable[]
      */
     public function findBy(array $fields): array;

--- a/src/Broadway/ReadModel/RepositoryFactory.php
+++ b/src/Broadway/ReadModel/RepositoryFactory.php
@@ -18,11 +18,5 @@ namespace Broadway\ReadModel;
  */
 interface RepositoryFactory
 {
-    /**
-     * @param string $name
-     * @param string $class
-     *
-     * @return Repository
-     */
     public function create(string $name, string $class): Repository;
 }

--- a/src/Broadway/ReadModel/Testing/ProjectorScenarioTestCase.php
+++ b/src/Broadway/ReadModel/Testing/ProjectorScenarioTestCase.php
@@ -27,14 +27,11 @@ abstract class ProjectorScenarioTestCase extends TestCase
      */
     protected $scenario;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->scenario = $this->createScenario();
     }
 
-    /**
-     * @return Scenario
-     */
     protected function createScenario(): Scenario
     {
         $repository = new InMemoryRepository();
@@ -42,8 +39,5 @@ abstract class ProjectorScenarioTestCase extends TestCase
         return new Scenario($this, $repository, $this->createProjector($repository));
     }
 
-    /**
-     * @return Projector
-     */
     abstract protected function createProjector(InMemoryRepository $repository): Projector;
 }

--- a/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestCase.php
@@ -23,7 +23,7 @@ abstract class RepositoryTestCase extends TestCase
      */
     protected $repository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->repository = $this->createRepository();
     }

--- a/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
+++ b/src/Broadway/ReadModel/Testing/RepositoryTestReadModel.php
@@ -23,10 +23,8 @@ class RepositoryTestReadModel implements SerializableReadModel
     private $array;
 
     /**
-     * @param mixed  $id
-     * @param string $name
-     * @param mixed  $foo
-     * @param array  $array
+     * @param mixed $id
+     * @param mixed $foo
      */
     public function __construct($id, string $name, $foo, array $array)
     {

--- a/src/Broadway/ReadModel/Testing/SerializableReadModelTestCase.php
+++ b/src/Broadway/ReadModel/Testing/SerializableReadModelTestCase.php
@@ -45,8 +45,5 @@ abstract class SerializableReadModelTestCase extends TestCase
         $this->assertEquals($readModel, $deserialized);
     }
 
-    /**
-     * @return SerializableReadModel
-     */
     abstract protected function createSerializableReadModel(): SerializableReadModel;
 }

--- a/src/Broadway/Repository/Repository.php
+++ b/src/Broadway/Repository/Repository.php
@@ -31,8 +31,6 @@ interface Repository
      * @param mixed $id
      *
      * @throws AggregateNotFoundException
-     *
-     * @return AggregateRoot
      */
     public function load($id): AggregateRoot;
 }

--- a/src/Broadway/Serializer/ReflectionSerializer.php
+++ b/src/Broadway/Serializer/ReflectionSerializer.php
@@ -46,11 +46,6 @@ class ReflectionSerializer implements Serializer
         return $value;
     }
 
-    /**
-     * @param array $array
-     *
-     * @return array
-     */
     private function serializeArrayRecursively(array $array): array
     {
         $data = [];
@@ -63,8 +58,6 @@ class ReflectionSerializer implements Serializer
 
     /**
      * @param object $object
-     *
-     * @return array
      */
     private function serializeObjectRecursively($object): array
     {
@@ -112,11 +105,6 @@ class ReflectionSerializer implements Serializer
         return $value;
     }
 
-    /**
-     * @param array $array
-     *
-     * @return array
-     */
     private function deserializeArrayRecursively(array $array): array
     {
         $data = [];
@@ -144,11 +132,7 @@ class ReflectionSerializer implements Serializer
         foreach ($serializedObject['payload'] as $name => $value) {
             $matchedProperty = $this->findProperty($properties, $name);
             if (null === $matchedProperty) {
-                throw new SerializationException(sprintf(
-                    'Property \'%s\' not found for object \'%s\'',
-                    $name,
-                    $serializedObject['class']
-                ));
+                throw new SerializationException(sprintf('Property \'%s\' not found for object \'%s\'', $name, $serializedObject['class']));
             }
 
             $value = $this->deserializeValue($value);

--- a/src/Broadway/Serializer/Serializable.php
+++ b/src/Broadway/Serializer/Serializable.php
@@ -23,8 +23,5 @@ interface Serializable
      */
     public static function deserialize(array $data);
 
-    /**
-     * @return array
-     */
     public function serialize(): array;
 }

--- a/src/Broadway/Serializer/Serializer.php
+++ b/src/Broadway/Serializer/Serializer.php
@@ -23,14 +23,10 @@ interface Serializer
      * @throws SerializationException
      *
      * @param mixed $object
-     *
-     * @return array
      */
     public function serialize($object): array;
 
     /**
-     * @param array $serializedObject
-     *
      * @throws SerializationException
      *
      * @return mixed

--- a/src/Broadway/Serializer/SimpleInterfaceSerializer.php
+++ b/src/Broadway/Serializer/SimpleInterfaceSerializer.php
@@ -26,10 +26,7 @@ final class SimpleInterfaceSerializer implements Serializer
     public function serialize($object): array
     {
         if (!$object instanceof Serializable) {
-            throw new SerializationException(sprintf(
-                'Object \'%s\' does not implement Broadway\Serializer\Serializable',
-                get_class($object)
-            ));
+            throw new SerializationException(sprintf('Object \'%s\' does not implement Broadway\Serializer\Serializable', get_class($object)));
         }
 
         return [
@@ -47,12 +44,7 @@ final class SimpleInterfaceSerializer implements Serializer
         Assert::keyExists($serializedObject, 'payload', "Key 'payload' should be set.");
 
         if (!in_array(Serializable::class, class_implements($serializedObject['class']))) {
-            throw new SerializationException(
-                sprintf(
-                    'Class \'%s\' does not implement Broadway\Serializer\Serializable',
-                    $serializedObject['class']
-                )
-            );
+            throw new SerializationException(sprintf('Class \'%s\' does not implement Broadway\Serializer\Serializable', $serializedObject['class']));
         }
 
         return $serializedObject['class']::deserialize($serializedObject['payload']);

--- a/test/Broadway/Auditing/CommandLoggerTest.php
+++ b/test/Broadway/Auditing/CommandLoggerTest.php
@@ -37,7 +37,7 @@ class CommandLoggerTest extends TestCase
      */
     private $commandSerializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->logger = new TraceableLogger();
 

--- a/test/Broadway/Auditing/NullByteCommandSerializerTest.php
+++ b/test/Broadway/Auditing/NullByteCommandSerializerTest.php
@@ -27,7 +27,7 @@ class NullByteCommandSerializerTest extends TestCase
      */
     private $command;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->commandSerializer = new NullByteCommandSerializer();
         $this->command = new MyCommand();

--- a/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
+++ b/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Broadway\CommandHandling;
 
 use Broadway\EventDispatcher\EventDispatcher;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class EventDispatchingCommandBusTest extends TestCase
@@ -43,7 +44,7 @@ class EventDispatchingCommandBusTest extends TestCase
      */
     private $subscriber;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventDispatcher = $this->createMock(EventDispatcher::class);
         $this->baseCommandBus = $this->createMock(CommandBus::class);
@@ -117,8 +118,6 @@ class EventDispatchingCommandBusTest extends TestCase
 class Command
 {
 }
-
-use Exception;
 
 class MyException extends Exception
 {

--- a/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
+++ b/test/Broadway/CommandHandling/EventDispatchingCommandBusTest.php
@@ -15,12 +15,13 @@ namespace Broadway\CommandHandling;
 
 use Broadway\EventDispatcher\EventDispatcher;
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class EventDispatchingCommandBusTest extends TestCase
 {
     /**
-     * @var CommandBus|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandBus|MockObject
      */
     private $baseCommandBus;
 
@@ -30,7 +31,7 @@ class EventDispatchingCommandBusTest extends TestCase
     private $command;
 
     /**
-     * @var EventDispatcher|\PHPUnit_Framework_MockObject_MockObject
+     * @var EventDispatcher|MockObject
      */
     private $eventDispatcher;
 
@@ -40,7 +41,7 @@ class EventDispatchingCommandBusTest extends TestCase
     private $eventDispatchingCommandBus;
 
     /**
-     * @var CommandHandler|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandHandler|MockObject
      */
     private $subscriber;
 

--- a/test/Broadway/CommandHandling/SimpleCommandBusTest.php
+++ b/test/Broadway/CommandHandling/SimpleCommandBusTest.php
@@ -22,7 +22,7 @@ class SimpleCommandBusTest extends TestCase
      */
     private $commandBus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->commandBus = new SimpleCommandBus();
     }

--- a/test/Broadway/CommandHandling/SimpleCommandBusTest.php
+++ b/test/Broadway/CommandHandling/SimpleCommandBusTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Broadway\CommandHandling;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SimpleCommandBusTest extends TestCase
@@ -103,7 +104,7 @@ class SimpleCommandBusTest extends TestCase
         $this->commandBus->dispatch($command2);
     }
 
-    private function createCommandHandlerMock(array $expectedCommand): \PHPUnit_Framework_MockObject_MockObject
+    private function createCommandHandlerMock(array $expectedCommand): MockObject
     {
         $mock = $this->createMock(CommandHandler::class);
 

--- a/test/Broadway/CommandHandling/Testing/TraceableCommandBusTest.php
+++ b/test/Broadway/CommandHandling/Testing/TraceableCommandBusTest.php
@@ -22,7 +22,7 @@ class TraceableCommandBusTest extends TestCase
      */
     private $commandBus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->commandBus = new TraceableCommandBus();
     }

--- a/test/Broadway/EventDispatcher/EventDispatcherTest.php
+++ b/test/Broadway/EventDispatcher/EventDispatcherTest.php
@@ -32,7 +32,7 @@ class EventDispatcherTest extends TestCase
      */
     private $listener2;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = new CallableEventDispatcher();
         $this->listener1 = new TracableEventListener();

--- a/test/Broadway/EventHandling/SimpleEventBusTest.php
+++ b/test/Broadway/EventHandling/SimpleEventBusTest.php
@@ -25,7 +25,7 @@ class SimpleEventBusTest extends TestCase
      */
     private $eventBus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventBus = new SimpleEventBus();
     }

--- a/test/Broadway/EventHandling/SimpleEventBusTest.php
+++ b/test/Broadway/EventHandling/SimpleEventBusTest.php
@@ -16,6 +16,7 @@ namespace Broadway\EventHandling;
 use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SimpleEventBusTest extends TestCase
@@ -144,7 +145,7 @@ class SimpleEventBusTest extends TestCase
         $this->eventBus->publish($domainEventStream2);
     }
 
-    private function createEventListenerMock(): \PHPUnit_Framework_MockObject_MockObject
+    private function createEventListenerMock(): MockObject
     {
         return $this->createMock(EventListener::class);
     }

--- a/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
+++ b/test/Broadway/EventSourcing/AbstractEventSourcingRepositoryTest.php
@@ -45,7 +45,7 @@ abstract class AbstractEventSourcingRepositoryTest extends TestCase
     /** @var EventSourcingRepository */
     protected $repository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventStore = new TraceableEventStore(new InMemoryEventStore());
         $this->eventStore->trace();

--- a/test/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactoryTest.php
+++ b/test/Broadway/EventSourcing/AggregateFactory/ReflectionAggregateFactoryTest.php
@@ -24,7 +24,7 @@ final class ReflectionAggregateFactoryTest extends TestCase
      */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new ReflectionAggregateFactory();
     }

--- a/test/Broadway/EventStore/ConcurrencyConflictResolver/BlacklistConcurrencyConflictResolverTest.php
+++ b/test/Broadway/EventStore/ConcurrencyConflictResolver/BlacklistConcurrencyConflictResolverTest.php
@@ -18,7 +18,7 @@ class BlacklistConcurrencyConflictResolverTest extends ConcurrencyConflictResolv
     /** @var BlacklistConcurrencyConflictResolver */
     private $conflictResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->conflictResolver = new BlacklistConcurrencyConflictResolver();
     }

--- a/test/Broadway/EventStore/ConcurrencyConflictResolver/WhitelistConcurrencyConflictResolverTest.php
+++ b/test/Broadway/EventStore/ConcurrencyConflictResolver/WhitelistConcurrencyConflictResolverTest.php
@@ -18,7 +18,7 @@ class WhitelistConcurrencyConflictResolverTest extends ConcurrencyConflictResolv
     /** @var WhitelistConcurrencyConflictResolver */
     private $conflictResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->conflictResolver = new WhitelistConcurrencyConflictResolver();
     }

--- a/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
+++ b/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
@@ -17,8 +17,8 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\ConcurrencyConflictResolver\ConcurrencyConflictResolver;
 use Broadway\EventStore\Testing\EventStoreTest;
-use Prophecy\Argument;
 use PHPUnit\Framework\MockObject\MockObject;
+use Prophecy\Argument;
 
 class ConflictResolvingEventStoreTest extends EventStoreTest
 {

--- a/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
+++ b/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
@@ -18,10 +18,11 @@ use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\ConcurrencyConflictResolver\ConcurrencyConflictResolver;
 use Broadway\EventStore\Testing\EventStoreTest;
 use Prophecy\Argument;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ConflictResolvingEventStoreTest extends EventStoreTest
 {
-    /** @var ConcurrencyConflictResolver|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var ConcurrencyConflictResolver|MockObject */
     protected $concurrencyResolver;
 
     protected function setUp(): void

--- a/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
+++ b/test/Broadway/EventStore/ConflictResolvingEventStoreTest.php
@@ -24,7 +24,7 @@ class ConflictResolvingEventStoreTest extends EventStoreTest
     /** @var ConcurrencyConflictResolver|\PHPUnit_Framework_MockObject_MockObject */
     protected $concurrencyResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->concurrencyResolver = $this->prophesize(ConcurrencyConflictResolver::class);
         $this->concurrencyResolver

--- a/test/Broadway/EventStore/InMemoryEventStoreTest.php
+++ b/test/Broadway/EventStore/InMemoryEventStoreTest.php
@@ -17,7 +17,7 @@ use Broadway\EventStore\Testing\EventStoreTest;
 
 class InMemoryEventStoreTest extends EventStoreTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventStore = new InMemoryEventStore();
     }

--- a/test/Broadway/Serializer/ReflectionSerializerTest.php
+++ b/test/Broadway/Serializer/ReflectionSerializerTest.php
@@ -23,7 +23,7 @@ class ReflectionSerializerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serializer = new ReflectionSerializer();
     }

--- a/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
+++ b/test/Broadway/Serializer/SimpleInterfaceSerializerTest.php
@@ -23,7 +23,7 @@ class SimpleInterfaceSerializerTest extends TestCase
      */
     private $serializer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serializer = new SimpleInterfaceSerializer();
     }


### PR DESCRIPTION
 - PHPUnit ^8.0 ready
 - php 7.4 ready
 - code sniffer fixes

Since this is bc break (php 7.4 is supported but php 7.1 is no longer supported and phpunit 8.0 is required) I hope new branch will be created (2.x) and current master left as branch 3.x