### PR TITLE
do not load all events to check for conflicts

### DIFF
--- a/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
@@ -37,6 +37,10 @@ final class ConcurrencyConflictResolvingEventStore implements EventStore
      */
     public function append($id, DomainEventStream $uncommittedEvents): void
     {
+        if (empty(iterator_to_array($uncommittedEvents))) {
+            return;
+        }
+
         try {
             $this->eventStore->append($id, $uncommittedEvents);
         } catch (DuplicatePlayheadException $e) {

--- a/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
@@ -37,6 +37,8 @@ final class ConcurrencyConflictResolvingEventStore implements EventStore
      */
     public function append($id, DomainEventStream $uncommittedEvents): void
     {
+        $id = (string)$id;
+
         if (empty(iterator_to_array($uncommittedEvents))) {
             return;
         }

--- a/src/Broadway/EventStore/Testing/EventStoreTest.php
+++ b/src/Broadway/EventStore/Testing/EventStoreTest.php
@@ -153,6 +153,20 @@ abstract class EventStoreTest extends TestCase
         $this->assertEquals($expected, $this->eventStore->loadFromPlayhead($id, 2));
     }
 
+    /** @test */
+    public function empty_set_of_events_can_be_added(): void
+    {
+        $domainMessage = $this->createDomainMessage(1, 0);
+        $baseStream = new DomainEventStream([$domainMessage]);
+        $this->eventStore->append(1, $baseStream);
+        $appendedEventStream = new DomainEventStream([]);
+
+        $this->eventStore->append(1, $appendedEventStream);
+
+        $events = $this->eventStore->load(1);
+        $this->assertCount(1, $events);
+    }
+
     /**
      * @test
      * @dataProvider idDataProvider


### PR DESCRIPTION
currently all events are loaded to check if there are concurrency conflicts.

It should be enough to load events from the initial playhead of the uncommitted events.

This could save some computations in case there are a bit of events before the conflicting playhead