### PR TITLE
docs: fix examples ref

### DIFF
--- a/docs/components/auditing.md
+++ b/docs/components/auditing.md
@@ -16,4 +16,4 @@ The [`examples/`][examples] directory at the root of the project contains a
 runnable auditing (`auditing`). The code you find there contains comments with
 what is happening.
 
-[examples]: ../../../examples/
+[examples]: ../../examples/

--- a/docs/components/command_handling.md
+++ b/docs/components/command_handling.md
@@ -49,4 +49,4 @@ The [`examples/`][examples] directory at the root of the project contains a
 runnable command handling example (`command-handling`). The code you find there
 contains comments with what is happening.
 
-[examples]: ../../../examples/
+[examples]: ../../examples/

--- a/docs/components/event_dispatcher.md
+++ b/docs/components/event_dispatcher.md
@@ -13,4 +13,4 @@ The [`examples/`][examples] directory at the root of the project contains a
 runnable event dispatcher example (`event-dispatcher`). The code you find there
 contains comments with what is happening.
 
-[examples]: ../../../examples/
+[examples]: ../../examples/

--- a/docs/components/event_handling.md
+++ b/docs/components/event_handling.md
@@ -13,4 +13,4 @@ The [`examples/`][examples] directory at the root of the project contains a
 runnable event handling example (`event-handling`). The code you find there
 contains comments with what is happening.
 
-[examples]: ../../../examples/
+[examples]: ../../examples/

--- a/docs/components/serializer.md
+++ b/docs/components/serializer.md
@@ -13,4 +13,4 @@ The [`examples/`][examples] directory at the root of the project contains a
 runnable serializer example (`serializer`). The code you find there
 contains comments with what is happening.
 
-[examples]: ../../../examples/
+[examples]: ../../examples/


### PR DESCRIPTION
the links to examples dir are broken, this PR fixes them
